### PR TITLE
Add support for permanent nodes

### DIFF
--- a/javascript/cable_ready.js
+++ b/javascript/cable_ready.js
@@ -11,6 +11,13 @@ const xpathToElement = xpath => {
   return document.evaluate(xpath, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
 };
 
+// Morphdom Callbacks ........................................................................................
+
+const onBeforeElChildrenUpdated = (fromEl, toEl) => {
+  const permanent = !!fromEl.dataset && fromEl.dataset.reflexPermanent !== undefined;
+  return !permanent;
+};
+
 const DOMOperations = {
   // DOM Events ..............................................................................................
 
@@ -26,7 +33,7 @@ const DOMOperations = {
     const template = document.createElement('template');
     template.innerHTML = String(html).trim();
     dispatch(element, 'cable-ready:before-morph', { ...detail, content: template.content });
-    morphdom(element, template.content, { childrenOnly: !!childrenOnly });
+    morphdom(element, template.content, { childrenOnly: !!childrenOnly, onBeforeElChildrenUpdated });
     if (focusSelector) document.querySelector(focusSelector).focus();
     dispatch(element, 'cable-ready:after-morph', { ...detail, content: template.content });
   },

--- a/javascript/cable_ready.js
+++ b/javascript/cable_ready.js
@@ -13,8 +13,8 @@ const xpathToElement = xpath => {
 
 // Morphdom Callbacks ........................................................................................
 
-const onBeforeElChildrenUpdated = (fromEl, toEl) => {
-  const permanent = !!fromEl.dataset && fromEl.dataset.reflexPermanent !== undefined;
+const onBeforeElUpdated = permanentAttributeName => (fromEl, toEl) => {
+  const permanent = !!fromEl.dataset && fromEl.dataset[permanentAttributeName] !== undefined;
   return !permanent;
 };
 
@@ -29,11 +29,14 @@ const DOMOperations = {
   // Element Mutations .......................................................................................
 
   morph: detail => {
-    const { element, html, childrenOnly, focusSelector } = detail;
+    const { element, html, childrenOnly, focusSelector, permanentAttributeName } = detail;
     const template = document.createElement('template');
     template.innerHTML = String(html).trim();
     dispatch(element, 'cable-ready:before-morph', { ...detail, content: template.content });
-    morphdom(element, template.content, { childrenOnly: !!childrenOnly, onBeforeElChildrenUpdated });
+    morphdom(element, template.content, {
+      childrenOnly: !!childrenOnly,
+      onBeforeElUpdated: onBeforeElUpdated(permanentAttributeName),
+    });
     if (focusSelector) document.querySelector(focusSelector).focus();
     dispatch(element, 'cable-ready:after-morph', { ...detail, content: template.content });
   },

--- a/javascript/cable_ready.js
+++ b/javascript/cable_ready.js
@@ -14,6 +14,10 @@ const xpathToElement = xpath => {
 // Morphdom Callbacks ........................................................................................
 
 const onBeforeElUpdated = permanentAttributeName => (fromEl, toEl) => {
+  // Skip nodes that are equal:
+  // https://github.com/patrick-steele-idem/morphdom#can-i-make-morphdom-blaze-through-the-dom-tree-even-faster-yes
+  if (fromEl.isEqualNode(toEl)) return false;
+
   const permanent = !!fromEl.dataset && fromEl.dataset[permanentAttributeName] !== undefined;
   return !permanent;
 };


### PR DESCRIPTION
## Description
Adds support for permanent nodes, i.e. nodes that will not be replaced when the DOM is updated.

I read through [this issue for stimulus_reflex](https://github.com/hopsoft/stimulus_reflex/pull/43#issuecomment-536801378), and decided to try to create a solution for this. Since I couldn't find a way to do this from the stimulus_reflex source code, I'm submitting this as a PR to cable_ready.

To mark a node as permanent, give it the `data-reflex-permanent`-attribute:
````html
<input name="email" data-reflex-permanent />
````

This is similar to [how Turbolinks supports similar behavior](https://github.com/turbolinks/turbolinks#persisting-elements-across-page-loads).

## Why should this be added

stimulus_reflex is an amazing project, and I was blown away by how easy it was to create highly interactive UIs without a complex javascript framework.

I did however run into a few issues, which this PR aims to solve:

1) **Input fields reset when triggering a reflex**

This is an issue with slightly more complex forms, e.g.:
- The user can select a payment plan from a group of radio buttons, and this change triggers a reflex that updates the order total.
- The user enters a username, and a reflex validates if the username is available.
- Stripe Elements get disconnected when their parent node is replaced, causing the input to be lost and the fields need to be reinitialized.

2) **Preservation of client-side state**

Some nodes may contain client-side state as data-attributes, etc. from other javascript frameworks. Now these nodes can be marked as permanent, and their state will not be reset every time a reflex is triggered.