### PR TITLE
Add Gitbook integration

### DIFF
--- a/.gitbook.yml
+++ b/.gitbook.yml
@@ -1,0 +1,5 @@
+root: ./docs/
+
+structure:
+  readme: README.md
+  summary: SUMMARY.md

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at natehop@gmail.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ to learn more about ActionCable before proceeding.
 
 ### Code of Conduct
 
-Everyone interacting with StimulusReflex is expected to follow the [Code of Conduct](CODE_OF_CONDUCT.md)
+Everyone interacting with CableReady is expected to follow the [Code of Conduct](CODE_OF_CONDUCT.md)
 
 ### Coding Standards
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,11 @@
-[![Lines of Code](http://img.shields.io/badge/lines_of_code-268-brightgreen.svg?style=flat)](http://blog.codinghorror.com/the-best-code-is-no-code-at-all/)
-[![Maintainability](https://api.codeclimate.com/v1/badges/83ddf1fee4af7e51a681/maintainability)](https://codeclimate.com/github/hopsoft/cable_ready/maintainability)
+---
+description: A simple interface for triggering client-side DOM operations
+from the server via ActionCable
+---
 
 # CableReady
+
+[![GitHub stars](https://img.shields.io/github/stars/hopsoft/cable_ready?style=social)](https://github.com/hopsoft/cable_ready) [![GitHub forks](https://img.shields.io/github/forks/hopsoft/cable_ready?style=social)](https://github.com/hopsoft/cable_ready) [![Twitter follow](https://img.shields.io/twitter/follow/hopsoft?style=social)](https://twitter.com/hopsoft)
 
 ## Out-of-Band Server Triggered DOM Operations
 
@@ -11,21 +15,11 @@ from the server via [ActionCable](http://guides.rubyonrails.org/action_cable_ove
 Please read the official [ActionCable docs](http://guides.rubyonrails.org/action_cable_overview.html)
 to learn more about ActionCable before proceeding.
 
-## Docs
-
-- [Official Documentation](https://docs.cableready.com)
-- [Documentation Source Code](https://github.com/hopsoft/cable_ready/tree/master/docs)
 
 ## Contributing
 
-### Code of Conduct
-
-Everyone interacting with StimulusReflex is expected to follow the [Code of Conduct](CODE_OF_CONDUCT.md)
-
-### Coding Standards
-
 This project uses [Standard](https://github.com/testdouble/standard)
-and [prettier-standard](https://github.com/sheerun/prettier-standard) to minimize bike shedding related to code formatting.
+and [Prettier](https://github.com/prettier/prettier) to minimize bike shedding related to code formatting.
 
 Please run `./bin/standardize` prior submitting pull requests.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,23 +14,3 @@ from the server via [ActionCable](http://guides.rubyonrails.org/action_cable_ove
 
 Please read the official [ActionCable docs](http://guides.rubyonrails.org/action_cable_overview.html)
 to learn more about ActionCable before proceeding.
-
-
-## Contributing
-
-This project uses [Standard](https://github.com/testdouble/standard)
-and [Prettier](https://github.com/prettier/prettier) to minimize bike shedding related to code formatting.
-
-Please run `./bin/standardize` prior submitting pull requests.
-
-### Releasing
-
-1. Bump version number at `lib/cable_ready/version.rb`
-1. Run `rake build`
-1. Run `rake release`
-1. Change directories `cd ./javascript`
-1. Run `yarn publish` - NOTE: this will throw a fatal error because the tag already exists but the package will still publish
-
-## License
-
-CableReady is released under the [MIT License](LICENSE.txt).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,5 @@
 ---
-description: A simple interface for triggering client-side DOM operations
-from the server via ActionCable
+description: A simple interface for triggering client-side DOM operations from the server via ActionCable
 ---
 
 # CableReady

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -1,0 +1,20 @@
+# Table of contents
+
+## Getting Started
+
+* [CableReady](README.md)
+* [Setup](setup.md)
+* [Usage](usage.md)
+
+## XPath
+
+* [XPath Example](xpath-example.md)
+
+## DOM Operations
+
+* [Supported DOM Operations](supported-dom-operations.md)
+    * [DOM Events](dom-operations/dom-events.md)
+    * [Attribute Mutations](dom-operations/attribute-mutations.md)
+    * [CSS Class Mutations](dom-operations/css-class-mutations.md)
+    * [Dataset Mutations](dom-operations/dataset-mutations.md)
+    * [Element Mutations](dom-operations/element-mutations.md)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -2,7 +2,6 @@
 
 ## Getting Started
 
-* [CableReady](README.md)
 * [Setup](setup.md)
 * [Usage](usage.md)
 

--- a/docs/dom-operations/attribute-mutations.md
+++ b/docs/dom-operations/attribute-mutations.md
@@ -1,0 +1,43 @@
+# Attribute Mutations
+
+## [setAttribute](https://developer.mozilla.org/en-US/docs/Web/API/Element/setAttribute)
+
+Sets an attribute on an element.
+
+{% code-tabs %}
+{% code-tabs-item %}
+```ruby
+cable_ready["MyChannel"].set_attribute(
+  selector: "string", # required - string containing a CSS selector or XPath expression
+  name:     "string", # required - the attribute to set
+  value:    "string"  # [null]   - the value to assign to the attribute
+)
+```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
+
+
+### JavaScript Events
+
+- `cable-ready:before-set-attribute`
+- `cable-ready:after-set-attribute`
+
+## [removeAttribute](https://developer.mozilla.org/en-US/docs/Web/API/Element/removeAttribute)
+
+Removes an attribute from an element.
+
+{% code-tabs %}
+{% code-tabs-item %}
+```ruby
+cable_ready["MyChannel"].remove_attribute(
+  selector: "string", # required - string containing a CSS selector or XPath expression
+  name:     "string"  # required - the attribute to remove
+)
+```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
+
+### JavaScript Events
+
+- `cable-ready:before-remove-attribute`
+- `cable-ready:after-remove-attribute`

--- a/docs/dom-operations/css-class-mutations.md
+++ b/docs/dom-operations/css-class-mutations.md
@@ -1,0 +1,43 @@
+# CSS Class Mutations
+
+## [addCssClass](https://developer.mozilla.org/en-US/docs/Web/API/Element/classList)
+
+Adds a CSS class to an element.
+This is a `noop` if the CSS class is already assigned.
+
+{% code-tabs %}
+{% code-tabs-item %}
+```ruby
+cable_ready["MyChannel"].add_css_class(
+  selector: "string", # required - string containing a CSS selector or XPath expression
+  name:     "string"  # [null]   - the CSS class to add
+)
+```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
+
+
+### JavaScript Events
+
+- `cable-ready:before-add-css-class`
+- `cable-ready:after-add-css-class`
+
+## [removeCssClass](https://developer.mozilla.org/en-US/docs/Web/API/Element/classList)
+
+Removes a CSS class from an element.
+
+{% code-tabs %}
+{% code-tabs-item %}
+```ruby
+cable_ready["MyChannel"].add_css_class(
+  selector: "string", # required - string containing a CSS selector or XPath expression
+  name:     "string"  # [null]   - the CSS class to remove
+)
+```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
+
+### JavaScript Events
+
+- `cable-ready:before-remove-css-class`
+- `cable-ready:after-remove-css-class`

--- a/docs/dom-operations/dataset-mutations.md
+++ b/docs/dom-operations/dataset-mutations.md
@@ -1,0 +1,23 @@
+# Dataset Mutations
+
+## [setDatasetProperty](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/dataset)
+
+Sets an dataset property (data-* attribute) on an element.
+
+{% code-tabs %}
+{% code-tabs-item %}
+```ruby
+cable_ready["MyChannel"].set_dataset_property(
+  selector: "string", # required - string containing a CSS selector or XPath expression
+  name:     "string", # required - the property to set
+  value:    "string"  # [null]   - the value to assign to the dataset
+)
+```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
+
+
+### JavaScript Events
+
+- `cable-ready:before-set-dataset-property`
+- `cable-ready:after-set-dataset-property`

--- a/docs/dom-operations/dom-events.md
+++ b/docs/dom-operations/dom-events.md
@@ -1,0 +1,19 @@
+# DOM Events
+
+## [dispatchEvent](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/dispatchEvent)
+
+{% hint style="info" %}
+Dispatches a DOM event in the browser.
+{% endhint %}
+
+{% code-tabs %}
+{% code-tabs-item %}
+```ruby
+cable_ready["MyChannel"].dispatch_event(
+  name:     "string", # required - the name of the DOM event to dispatch (can be custom)
+  detail:   "object", # [null]   - assigned to event.detail
+  selector: "string"  # [window] - string containing a CSS selector or XPath expression
+)
+```
+{% endcode-tabs-item %}
+{% endcode-tabs %}

--- a/docs/dom-operations/element-mutations.md
+++ b/docs/dom-operations/element-mutations.md
@@ -1,0 +1,202 @@
+# Element Mutations
+
+## [morph](https://github.com/patrick-steele-idem/morphdom)
+
+{% hint style="info" %}
+[Fast lightweight DOM diffing/patching](https://github.com/patrick-steele-idem/morphdom) without a virtual DOM.
+{% endhint %}
+
+{% code-tabs %}
+{% code-tabs-item %}
+```ruby
+cable_ready["MyChannel"].morph(
+  selector:       "string",           # required - string containing a CSS selector or XPath expression
+  html:           "string",           # [null]   - the HTML to assign
+  children_only:  true|false,         # [null]   - indicates if only child nodes should be morphed... skipping the parent element
+  permanent_attribute_name: "string", # [null]   - an attribute name that prevents elements from being updated i.e. "data-permanent"
+  focus_selector: "string",           # [null]   - string containing a CSS selector
+)
+```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
+
+### JavaScript Events
+
+- `cable-ready:before-morph`
+- `cable-ready:after-morph`
+
+### Stimulus Gotchas
+
+{% hint style="warning" %}
+For some reason [Stimulus](https://github.com/stimulusjs/stimulus) controllers don't reconnect after DOM mutations triggered by [Morphdom](https://github.com/patrick-steele-idem/morphdom).
+{% endhint %}
+
+You can force your controllers to reconnect with the following code.
+
+{% code-tabs %}
+{% code-tabs-item %}
+```javascript
+import { Controller } from "stimulus"
+
+export default class extends Controller {
+  connect() {
+    this.name = this.element.dataset.controller;
+    document.addEventListener('cable-ready:after-morph', this.reconnect.bind(this));
+    );
+  }
+
+  reconnect() {
+    setTimeout(() => this.element.setAttribute('data-controller', this.name), 1);
+    this.element.setAttribute('data-controller', '');
+  }
+}
+```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
+
+## [innerHTML](https://developer.mozilla.org/en-US/docs/Web/API/Element/innerHTML)
+
+Sets the innerHTML of a DOM element.
+
+{% code-tabs %}
+{% code-tabs-item %}
+```ruby
+cable_ready["MyChannel"].inner_html(
+  selector:       "string", # required - string containing a CSS selector or XPath expression
+  focus_selector: "string", # [null]   - string containing a CSS selector
+  html:           "string"  # [null]   - the HTML to assign
+)
+```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
+
+### JavaScript Events
+
+- `cable-ready:before-inner-html`
+- `cable-ready:after-inner-html`
+
+## [outerHTML](https://developer.mozilla.org/en-US/docs/Web/API/Element/outerHTML)
+
+Replaces a DOM element with new HTML.
+
+{% code-tabs %}
+{% code-tabs-item %}
+```ruby
+cable_ready["MyChannel"].outerHTML(
+  selector:       "string", # required - string containing a CSS selector or XPath expression
+  focus_selector: "string", # [null]   - string containing a CSS selector
+  html:           "string"  # [null]   - the HTML to use as replacement
+)
+```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
+
+### JavaScript Events
+
+- `cable-ready:before-outer-html`
+- `cable-ready:after-outer-html`
+
+## [textContent](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent)
+
+Sets the text content of a DOM element.
+
+{% code-tabs %}
+{% code-tabs-item %}
+```ruby
+cable_ready["MyChannel"].text_content(
+  selector: "string", # required - string containing a CSS selector or XPath expression
+  text:     "string"  # [null]   - the text to assign
+)
+```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
+
+### JavaScript Events
+
+- `cable-ready:before-text-content`
+- `cable-ready:after-text-content`
+
+## [insertAdjacentHTML](https://developer.mozilla.org/en-US/docs/Web/API/Element/insertAdjacentHTML)
+
+Inserts HTML into the DOM relative to an element.
+Supports behavior akin to prepend & append.
+
+{% code-tabs %}
+{% code-tabs-item %}
+```ruby
+cable_ready["MyChannel"].insert_adjacent_html(
+  selector:       "string", # required    - string containing a CSS selector or XPath expression
+  focus_selector: "string", # [null]      - string containing a CSS selector
+  position:       "string", # [beforeend] - the relative position to the DOM element (beforebegin, afterbegin, beforeend, afterend)
+  html:           "string"  # [null]      - the HTML to insert
+)
+```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
+
+### JavaScript Events
+
+- `cable-ready:before-insert-adjacent-html`
+- `cable-ready:after-insert-adjacent-html`
+
+## [insertAdjacentText](https://developer.mozilla.org/en-US/docs/Web/API/Element/insertAdjacentText)
+
+Inserts text into the DOM relative to an element.
+Supports behavior akin to prepend & append.
+
+{% code-tabs %}
+{% code-tabs-item %}
+```ruby
+cable_ready["MyChannel"].insert_adjacent_text(
+  selector: "string", # required    - string containing a CSS selector or XPath expression
+  position: "string", # [beforeend] - the relative position to the DOM element (beforebegin, afterbegin, beforeend, afterend)
+  text:     "string"  # [null]      - the text to insert
+)
+```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
+
+### JavaScript Events
+
+- `cable-ready:before-insert-adjacent-text`
+- `cable-ready:after-insert-adjacent-text`
+
+## [remove](https://developer.mozilla.org/en-US/docs/Web/API/ChildNode/remove)
+
+Removes an element from the DOM.
+
+{% code-tabs %}
+{% code-tabs-item %}
+```ruby
+cable_ready["MyChannel"].remove(
+  selector:       "string", # required - string containing a CSS selector or XPath expression
+  focus_selector: "string"  # [null]   - string containing a CSS selector
+)
+```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
+
+### JavaScript Events
+
+- `cable-ready:before-remove`
+- `cable-ready:after-remove`
+
+## [setValue](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement)
+
+Sets the value of an element.
+
+{% code-tabs %}
+{% code-tabs-item %}
+```ruby
+cable_ready["MyChannel"].set_value(
+  selector: "string", # required - string containing a CSS selector or XPath expression
+  value:    "string"  # [null]   - the value to assign to the attribute
+)
+```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
+
+### JavaScript Events
+
+- `cable-ready:before-set-value`
+- `cable-ready:after-set-value`

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,17 @@
+---
+description: How to get setup with CableReady
+---
+
+## Setup
+
+```bash
+yarn add cable_ready
+```
+
+{% code-tabs %}
+{% code-tabs-item title="Gemfile" %}
+```ruby
+gem "cable_ready"
+```
+{% endcode-tabs-item %}
+{% endcode-tabs %}

--- a/docs/supported-dom-operations.md
+++ b/docs/supported-dom-operations.md
@@ -4,7 +4,10 @@ description: DOM operations you can leverage with CableReady
 
 ## Supported DOM Operations
 
+### [DOM Events](dom-operations/dom-events.md)
 - [dispatchEvent](dom-operations/dom-events.md#dispatchevent)
+
+### [Element Mutations](dom-operations/element-mutations.md)
 - [morph](dom-operations/element-mutations.md#morph)
 - [innerHTML](dom-operations/element-mutations.md#innerhtml)
 - [outerHTML](dom-operations/element-mutations.md#outerhtml)
@@ -12,10 +15,16 @@ description: DOM operations you can leverage with CableReady
 - [insertAdjacentText](dom-operations/element-mutations.md#insertadjacenttext)
 - [remove](dom-operations/element-mutations.md#remove)
 - [setValue](dom-operations/element-mutations.md#setvalue)
+
+### [Attribute Mutations](dom-operations/attribute-mutations.md)
 - [setAttribute](dom-operations/attribute-mutations.md#setattribute)
 - [removeAttribute](dom-operations/attribute-mutations.md#removeattribute)
+
+### [CSS Class Mutations](dom-operations/css-class-mutations.md)
 - [addCssClass](dom-operations/css-class-mutations.md#addcssclass)
 - [removeCssClass](dom-operations/css-class-mutations.md#removecssclass)
+
+### [Dataset Mutations](dom-operations/dataset-mutations.md)
 - [setDatasetProperty](dom-operations/dataset-mutations.md#setdatasetproperty)
 
 {% hint style="info" %}

--- a/docs/supported-dom-operations.md
+++ b/docs/supported-dom-operations.md
@@ -1,0 +1,31 @@
+---
+description: DOM operations you can leverage with CableReady
+---
+
+## Supported DOM Operations
+
+- [dispatchEvent](dom-operations/dom-events.md#dispatchevent)
+- [morph](dom-operations/element-mutations.md#morph)
+- [innerHTML](dom-operations/element-mutations.md#innerhtml)
+- [outerHTML](dom-operations/element-mutations.md#outerhtml)
+- [insertAdjacentHTML](dom-operations/element-mutations.md#insertAdjacentHTML)
+- [insertAdjacentText](dom-operations/element-mutations.md#insertadjacenttext)
+- [remove](dom-operations/element-mutations.md#remove)
+- [setValue](dom-operations/element-mutations.md#setvalue)
+- [setAttribute](dom-operations/attribute-mutations.md#setattribute)
+- [removeAttribute](dom-operations/attribute-mutations.md#removeattribute)
+- [addCssClass](dom-operations/css-class-mutations.md#addcssclass)
+- [removeCssClass](dom-operations/css-class-mutations.md#removecssclass)
+- [setDatasetProperty](dom-operations/dataset-mutations.md#setdatasetproperty)
+
+{% hint style="info" %}
+The `selector` options use [document.querySelector()](https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector) to find an element by default. [XPath](https://developer.mozilla.org/en-US/docs/Web/XPath) expressions can also be used if the `xpath` option is set to `true`. As with CSS selectors, the XPath expression must resolve to a single element and not a collection.
+{% endhint %}
+
+{% hint style="info" %}
+It's possible to invoke multiple DOM operations with a single ActionCable broadcast.
+{% endhint %}
+
+{% hint style="info" %}
+All DOM mutations have corresponding `before/after` events triggered on `document`. These events expose `event.detail` set to the arguments from the server.
+{% endhint %}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,36 @@
+---
+description: How to use CableReady
+---
+
+## Usage
+
+{% code-tabs %}
+{% code-tabs-item title="app/assets/javascripts/channels/user.js" %}
+```javascript
+import CableReady from 'cable_ready';
+
+App.cable.subscriptions.create({ channel: "UserChannel" }, {
+  received: function (data) {
+    if (data.cableReady) {
+      CableReady.perform(data.operations);
+    }
+  }
+});
+```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
+
+{% code-tabs %}
+{% code-tabs-item title="app/models/user.rb" %}
+```ruby
+class User < ApplicationRecord
+  include CableReady::Broadcaster
+
+  def broadcast_name_change
+    cable_ready["UserChannel"].text_content selector: "#user-name", text: name
+    cable_ready.broadcast
+  end
+end
+```
+{% endcode-tabs-item %}
+{% endcode-tabs %}

--- a/docs/xpath-example.md
+++ b/docs/xpath-example.md
@@ -1,0 +1,20 @@
+---
+description: Example of using Xpath with CableReady
+---
+
+## Xpath Example
+
+{% code-tabs %}
+{% code-tabs-item title="app/models/user.rb" %}
+```ruby
+class User < ApplicationRecord
+  include CableReady::Broadcaster
+
+  def broadcast_name_change
+    cable_ready["UserChannel"].text_content selector: "/html/body/div[1]/form/input[1]", text: name, xpath: true
+    cable_ready.broadcast
+  end
+end
+```
+{% endcode-tabs-item %}
+{% endcode-tabs %}


### PR DESCRIPTION
Reorganize the documentation into a `docs/` folder and add gitbook styling. Also updates the README and adds COC.

## Example Screenshot

![image](https://user-images.githubusercontent.com/18423853/66246302-3cd5c100-e6c8-11e9-97fd-cc52109d7207.png)
