### PR TITLE
adding support for prepend and append

### DIFF
--- a/javascript/cable_ready.js
+++ b/javascript/cable_ready.js
@@ -22,8 +22,9 @@ const shouldMorph = permanentAttributeName => (fromEl, toEl) => {
   // Skip nodes that are equal:
   // https://github.com/patrick-steele-idem/morphdom#can-i-make-morphdom-blaze-through-the-dom-tree-even-faster-yes
   if (fromEl.isEqualNode(toEl)) return false
-  if (permanentAttributeName && fromEl.closest(`[${permanentAttributeName}]`))
+  if (permanentAttributeName && fromEl.closest(`[${permanentAttributeName}]`)) {
     return false
+  }
   return true
 }
 
@@ -45,10 +46,18 @@ const DOMOperations = {
       html,
       childrenOnly,
       focusSelector,
-      permanentAttributeName
+      permanentAttributeName,
+      appendAttributeName,
+      prependAttributeName
     } = detail
     const template = document.createElement('template')
-    template.innerHTML = String(html).trim()
+    if (element.hasAttribute(appendAttributeName)) {
+      template.innerHTML = element.innerHTML + String(html).trim()
+    } else if (element.hasAttribute(prependAttributeName)) {
+      template.innerHTML = String(html).trim() + element.innerHTML
+    } else {
+      template.innerHTML = String(html).trim()
+    }
     dispatch(element, 'cable-ready:before-morph', {
       ...detail,
       content: template.content

--- a/lib/cable_ready/channel.rb
+++ b/lib/cable_ready/channel.rb
@@ -20,6 +20,8 @@ module CableReady
     #     html:          "string"
     #     children_only:  true|false,
     #     permanent_attribute_name: "string",
+    #     append_attribute_name: "string",
+    #     prepend_attribute_name: "string",
     #     focus_selector: "string",
     #   }, ...],
     #


### PR DESCRIPTION
Honestly, not convinced that this is the most performant mechanism. [Possible we could use element.insertAdjacentHTML](https://developer.mozilla.org/en-US/docs/Web/API/Element/insertAdjacentHTML) and be more efficient.

[LiveView implementation here](https://github.com/phoenixframework/phoenix_live_view/blob/c9da19460ba401a0d6fc1ca775f03f9cc6e3c150/assets/js/phoenix_live_view.js#L862). They call element.cloneNode().innerHTML and it's possible this is more effective.

Tandem PR with [StimulusReflex PR 87](https://github.com/hopsoft/stimulus_reflex/pull/87).