### PR TITLE
Add support to ignore missing DOM elements via options parameter

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -10,25 +10,35 @@ yarn add cable_ready
 
 {% code-tabs %}
 {% code-tabs-item title="Gemfile" %}
+
 ```ruby
 gem "cable_ready"
 ```
+
 {% endcode-tabs-item %}
 {% endcode-tabs %}
 
 {% code-tabs %}
 {% code-tabs-item title="app/assets/javascripts/channels/user.js" %}
-```javascript
-import CableReady from 'cable_ready';
 
-App.cable.subscriptions.create({ channel: "UserChannel" }, {
-  received: function (data) {
-    if (data.cableReady) {
-      CableReady.perform(data.operations);
+```javascript
+import CableReady from 'cable_ready'
+
+App.cable.subscriptions.create(
+  { channel: 'UserChannel' },
+  {
+    received: function (data) {
+      if (data.cableReady) {
+        CableReady.perform(data.operations)
+      }
     }
   }
-});
+)
 ```
+
 {% endcode-tabs-item %}
 {% endcode-tabs %}
 
+{% hint style="info" %}
+By default, CableReady will emit a warning to the console log if it cannot find a DOM element matching the specified selector. If you would prefer to silently ignore operations on elements that don't exist, CableReady.perform accepts an options object as a second parameter: `CableReady.perform(data.operations, { processMissing: false })`
+{% endhint %}

--- a/javascript/cable_ready.js
+++ b/javascript/cable_ready.js
@@ -158,7 +158,7 @@ const DOMOperations = {
   }
 }
 
-const perform = operations => {
+const perform = (operations, options = { processMissing: true }) => {
   for (let name in operations) {
     if (operations.hasOwnProperty(name)) {
       const entries = operations[name]
@@ -172,9 +172,13 @@ const perform = operations => {
           } else {
             detail.element = document
           }
-          DOMOperations[name](detail)
+          if (detail.element || options.processMissing)
+            DOMOperations[name](detail)
         } catch (e) {
-          console.log(`CableReady detected an error in ${name}! ${e.message}`)
+          if (entries[i].element)
+            console.log(`CableReady detected an error in ${name}! ${e.message}`)
+          else
+            console.log(`CableReady ${name} failed due to missing DOM element.`)
         }
       }
     }

--- a/javascript/cable_ready.js
+++ b/javascript/cable_ready.js
@@ -158,7 +158,10 @@ const DOMOperations = {
   }
 }
 
-const perform = (operations, options = { processMissing: true }) => {
+const perform = (
+  operations,
+  options = { emitMissingElementWarnings: true }
+) => {
   for (let name in operations) {
     if (operations.hasOwnProperty(name)) {
       const entries = operations[name]
@@ -172,7 +175,7 @@ const perform = (operations, options = { processMissing: true }) => {
           } else {
             detail.element = document
           }
-          if (detail.element || options.processMissing)
+          if (detail.element || options.emitMissingElementWarnings)
             DOMOperations[name](detail)
         } catch (e) {
           if (entries[i].element)


### PR DESCRIPTION
While it is desirable to emit console log messages when an invalid DOM selector is received in development, in production there should be an escape hatch to suppress messages if a valid reason exists to do so.

This PR introduces an optional 2nd parameter to the perform method, an object called options. Currently, this object has a single key  `processMissing` which defaults to true. If set to false, DOMOperations will not be called unless there is a valid element in scope.

I added a documentation hint and supplemented the original catch block with a distinction to alert developers to the missing DOM element. I spent a lot of time trying to figure out what was going wrong before realizing that the element was missing due to an unhelpful default error message.