### PR TITLE
add set_style method to library

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -38,7 +38,8 @@ CableReady supports the following DOM operations that can be triggered from serv
 10. [removeAttribute](usage/dom-operations/attribute-mutations.md#removeattribute)
 11. [addCssClass](usage/dom-operations/css-class-mutations.md#addcssclass)
 12. [removeCssClass](usage/dom-operations/css-class-mutations.md#removecssclass)
-13. [setDatasetProperty](usage/dom-operations/dataset-mutations.md#setdatasetproperty)
+13. [setStyle](usage/dom-operations/css-class-mutations.md#setstyle)
+14. [setDatasetProperty](usage/dom-operations/dataset-mutations.md#setdatasetproperty)
 
 As with other new tools, the potential use cases are only limited by your imagination. For example, CableReady provides the foundation for incredible libraries like [StimulusReflex](https://docs.stimulusreflex.com).
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -11,4 +11,5 @@
   * [CSS Class Mutations](usage/dom-operations/css-class-mutations.md)
   * [Dataset Mutations](usage/dom-operations/dataset-mutations.md)
   * [Element Mutations](usage/dom-operations/element-mutations.md)
+  * [Style Mutations](usage/dom-operations/style-mutations.md)
 

--- a/docs/usage/dom-operations/README.md
+++ b/docs/usage/dom-operations/README.md
@@ -36,6 +36,10 @@ All DOM mutations have corresponding `before/after` events triggered on `documen
 * [addCssClass](css-class-mutations.md#addcssclass)
 * [removeCssClass](css-class-mutations.md#removecssclass)
 
+## [Style Mutations](style-mutations.md)
+
+* [setStyle](style-mutations.md#setstyle)
+
 ## [Dataset Mutations](dataset-mutations.md)
 
 * [setDatasetProperty](dataset-mutations.md#setdatasetproperty)

--- a/docs/usage/dom-operations/style-mutations.md
+++ b/docs/usage/dom-operations/style-mutations.md
@@ -1,0 +1,18 @@
+# Style Mutations
+
+## [setStyle](https://developer.mozilla.org/en-US/docs/Web/API/ElementCSSInlineStyle/style)
+
+Sets a single style on an element.
+
+```ruby
+cable_ready["MyChannel"].set_style(
+  selector: "string", # required - string containing a CSS selector or XPath expression
+  name:     "string", # required - the style to set
+  value:    "string"  # [null]   - the value to assign to the style
+)
+```
+
+### JavaScript Events
+
+* `cable-ready:before-set-style`
+* `cable-ready:after-set-style`

--- a/javascript/cable_ready.js
+++ b/javascript/cable_ready.js
@@ -154,6 +154,15 @@ const DOMOperations = {
     dispatch(element, 'cable-ready:after-remove-css-class', detail)
   },
 
+  // Style Mutations .......................................................................................
+
+  setStyle: detail => {
+    const { element, name, value } = detail
+    dispatch(element, 'cable-ready:before-set-style', detail)
+    element.style[name] = value
+    dispatch(element, 'cable-ready:after-set-style', detail)
+  },
+
   // Dataset Mutations .......................................................................................
 
   setDatasetProperty: detail => {

--- a/lib/cable_ready/channel.rb
+++ b/lib/cable_ready/channel.rb
@@ -95,6 +95,14 @@ module CableReady
     #     name:     "string"
     #   }, ...],
     #
+    #   # Style Mutations ...........................................................................................
+    #
+    #   set_style: [{
+    #     selector: "string",
+    #     name:     "string",
+    #     value:    "string"
+    #   }, ...],
+    #
     #   # Dataset Mutations ...........................................................................................
     #
     #   set_dataset_property: [{
@@ -175,6 +183,10 @@ module CableReady
       add_operation(:remove_css_class, options)
     end
 
+    def set_style(options = {})
+      add_operation(:set_style, options)
+    end
+
     def set_dataset_property(options = {})
       add_operation(:set_dataset_property, options)
     end
@@ -201,6 +213,7 @@ module CableReady
         set_attribute: [],
         set_cookie: [],
         set_dataset_property: [],
+        set_style: [],
         set_value: [],
         text_content: []
       }


### PR DESCRIPTION
While this isn't something you should be doing every day, dynamically setting an element's in-line style values is a legitimate intention in edge case scenarios. I believe that it was omitted from the library by virtue of being overlooked.

While it is possible to use the setAttribute method to update an element's in-line style attribute as a string, setting it actually overwrites any previous values. In other words, you either have to track which styles are set, or you have to arbitrarily limit developers to setting one style at a time.