### PR TITLE
add set_property method to library

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -33,13 +33,14 @@ CableReady supports the following DOM operations that can be triggered from serv
 5. [insertAdjacentHTML](usage/dom-operations/element-mutations.md#insertAdjacentHTML)
 6. [insertAdjacentText](usage/dom-operations/element-mutations.md#insertadjacenttext)
 7. [remove](usage/dom-operations/element-mutations.md#remove)
-8. [setValue](usage/dom-operations/element-mutations.md#setvalue)
-9. [setAttribute](usage/dom-operations/attribute-mutations.md#setattribute)
-10. [removeAttribute](usage/dom-operations/attribute-mutations.md#removeattribute)
-11. [addCssClass](usage/dom-operations/css-class-mutations.md#addcssclass)
-12. [removeCssClass](usage/dom-operations/css-class-mutations.md#removecssclass)
-13. [setStyle](usage/dom-operations/css-class-mutations.md#setstyle)
-14. [setDatasetProperty](usage/dom-operations/dataset-mutations.md#setdatasetproperty)
+8. [setProperty](usage/dom-operations/element-mutations.md#setproperty)
+9. [setValue](usage/dom-operations/element-mutations.md#setvalue)
+10. [setAttribute](usage/dom-operations/attribute-mutations.md#setattribute)
+11. [removeAttribute](usage/dom-operations/attribute-mutations.md#removeattribute)
+12. [addCssClass](usage/dom-operations/css-class-mutations.md#addcssclass)
+13. [removeCssClass](usage/dom-operations/css-class-mutations.md#removecssclass)
+14. [setStyle](usage/dom-operations/css-class-mutations.md#setstyle)
+15. [setDatasetProperty](usage/dom-operations/dataset-mutations.md#setdatasetproperty)
 
 As with other new tools, the potential use cases are only limited by your imagination. For example, CableReady provides the foundation for incredible libraries like [StimulusReflex](https://docs.stimulusreflex.com).
 

--- a/docs/usage/dom-operations/README.md
+++ b/docs/usage/dom-operations/README.md
@@ -24,6 +24,7 @@ All DOM mutations have corresponding `before/after` events triggered on `documen
 * [insertAdjacentHTML](element-mutations.md#insertAdjacentHTML)
 * [insertAdjacentText](element-mutations.md#insertadjacenttext)
 * [remove](element-mutations.md#remove)
+* [setProperty](element-mutations.md#setproperty)
 * [setValue](element-mutations.md#setvalue)
 
 ## [Attribute Mutations](attribute-mutations.md)

--- a/docs/usage/dom-operations/element-mutations.md
+++ b/docs/usage/dom-operations/element-mutations.md
@@ -122,6 +122,23 @@ cable_ready["MyChannel"].remove(
 * `cable-ready:before-remove`
 * `cable-ready:after-remove`
 
+## [setProperty](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Working_with_Objects)
+
+Sets a valid property on an element to a new value.
+
+```ruby
+cable_ready["MyChannel"].set_property(
+  name:     "string", # required - string containing a valid property
+  selector: "string", # required - string containing a CSS selector or XPath expression
+  value:    "string"  # [null]   - the value to assign to the property
+)
+```
+
+### JavaScript Events
+
+* `cable-ready:before-set-property`
+* `cable-ready:after-set-property`
+
 ## [setValue](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement)
 
 Sets the value of an element.
@@ -137,4 +154,3 @@ cable_ready["MyChannel"].set_value(
 
 * `cable-ready:before-set-value`
 * `cable-ready:after-set-value`
-

--- a/javascript/cable_ready.js
+++ b/javascript/cable_ready.js
@@ -187,6 +187,13 @@ const DOMOperations = {
     dispatch(element, 'cable-ready:after-remove', detail)
   },
 
+  setProperty: detail => {
+    const { element, name, value } = detail
+    dispatch(element, 'cable-ready:before-set-property', detail)
+    if (name in element) element[name] = value
+    dispatch(element, 'cable-ready:after-set-property', detail)
+  },
+
   setValue: detail => {
     const { element, value } = detail
     dispatch(element, 'cable-ready:before-set-value', detail)

--- a/lib/cable_ready/channel.rb
+++ b/lib/cable_ready/channel.rb
@@ -65,6 +65,12 @@ module CableReady
     #     focus_selector: "string,
     #   }, ...],
     #
+    #   set_property: [{
+    #     name:     "string",
+    #     selector: "string",
+    #     value:    "string"
+    #   }, ...],
+    #
     #   set_value: [{
     #     selector: "string",
     #     value:    "string"
@@ -163,6 +169,10 @@ module CableReady
       add_operation(:remove, options)
     end
 
+    def set_property(options = {})
+      add_operation(:set_property, options)
+    end
+
     def set_value(options = {})
       add_operation(:set_value, options)
     end
@@ -214,6 +224,7 @@ module CableReady
         set_cookie: [],
         set_dataset_property: [],
         set_style: [],
+        set_property: [],
         set_value: [],
         text_content: []
       }


### PR DESCRIPTION
A marriage of set_attribute and set_value...

While it is true that 90% of the time you want to use set_attribute or set_value, there are scenarios in which a developer might want to set a property on an element.

This implementation runs a simple check to verify that a given property name is present in the element's property dictionary before setting the value. It does **not** attempt to verify that the developer has passed a value that is compatible with the property's data type. If someone tries to set an invalid data type, it will be caught by CR's standard try/catch error handling.