### PR TITLE
Print out the selector for easier debugging perform errors

### DIFF
--- a/javascript/cable_ready.js
+++ b/javascript/cable_ready.js
@@ -268,7 +268,9 @@ const perform = (
           if (detail.element)
             console.log(`CableReady detected an error in ${name}! ${e.message}`)
           else
-            console.log(`CableReady ${name} failed due to missing DOM element for selector: '${detail.selector}'`)
+            console.log(
+              `CableReady ${name} failed due to missing DOM element for selector: '${detail.selector}'`
+            )
         }
       }
     }

--- a/javascript/cable_ready.js
+++ b/javascript/cable_ready.js
@@ -253,8 +253,8 @@ const perform = (
     if (operations.hasOwnProperty(name)) {
       const entries = operations[name]
       for (let i = 0; i < entries.length; i++) {
+        const detail = entries[i]
         try {
-          const detail = entries[i]
           if (detail.selector) {
             detail.element = detail.xpath
               ? xpathToElement(detail.selector)
@@ -265,10 +265,10 @@ const perform = (
           if (detail.element || options.emitMissingElementWarnings)
             DOMOperations[name](detail)
         } catch (e) {
-          if (entries[i].element)
+          if (detail.element)
             console.log(`CableReady detected an error in ${name}! ${e.message}`)
           else
-            console.log(`CableReady ${name} failed due to missing DOM element.`)
+            console.log(`CableReady ${name} failed due to missing DOM element for selector: '${detail.selector}'`)
         }
       }
     }


### PR DESCRIPTION
This PR improves the error message when the sector fails by printing out the selector. You can easily grab that and run it in the console for debugging. 

```
CableReady morph failed due to missing DOM element for selector: 'card_3'
```

I ran into this when I was generating a `dom_id` in Ruby, without the `#` but it took me a bit to realize why.

Figured this would be useful for other people debugging their cable ready broadcasts.