### PR TITLE
Add setStyles

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -39,6 +39,7 @@ CableReady supports the following DOM operations that can be triggered from serv
 11. [addCssClass](usage/dom-operations/css-class-mutations.md#addcssclass)
 12. [removeCssClass](usage/dom-operations/css-class-mutations.md#removecssclass)
 13. [setStyle](usage/dom-operations/css-class-mutations.md#setstyle)
+13. [setStyles](usage/dom-operations/css-class-mutations.md#setstyles)
 14. [setDatasetProperty](usage/dom-operations/dataset-mutations.md#setdatasetproperty)
 
 As with other new tools, the potential use cases are only limited by your imagination. For example, CableReady provides the foundation for incredible libraries like [StimulusReflex](https://docs.stimulusreflex.com).

--- a/docs/usage/dom-operations/style-mutations.md
+++ b/docs/usage/dom-operations/style-mutations.md
@@ -17,3 +17,17 @@ cable_ready["MyChannel"].set_style(
 * `cable-ready:before-set-style`
 * `cable-ready:after-set-style`
 
+## [setStyles](https://developer.mozilla.org/en-US/docs/Web/API/ElementCSSInlineStyle/style)
+
+Sets a multiple styles on an element. This delegates each entry in
+`styles` to `setStyle` so you can set multiple values at once.
+
+```ruby
+cable_ready["MyChannel"].set_styles(
+  selector: "string", # required - string containing a CSS selector or XPath expression
+  styles: {
+    background: "red",
+    color: "white"
+  }
+)
+```

--- a/javascript/cable_ready.js
+++ b/javascript/cable_ready.js
@@ -235,6 +235,15 @@ const DOMOperations = {
     dispatch(element, 'cable-ready:after-set-style', detail)
   },
 
+  setStyles: detail => {
+    const { element, styles } = detail
+    for (const property in styles) {
+      const name = property,
+        value = styles[property]
+      DOMOperations['setStyle']({ element: element, name: name, value: value })
+    }
+  },
+
   // Dataset Mutations .......................................................................................
 
   setDatasetProperty: detail => {

--- a/javascript/cable_ready.js
+++ b/javascript/cable_ready.js
@@ -237,11 +237,11 @@ const DOMOperations = {
 
   setStyles: detail => {
     const { element, styles } = detail
-    for (const property in styles) {
-      const name = property,
-        value = styles[property]
-      DOMOperations['setStyle']({ element: element, name: name, value: value })
+    dispatch(element, 'cable-ready:before-set-styles', detail)
+    for (let [name, value] of Object.entries(styles)) {
+      element.style[name] = value
     }
+    dispatch(element, 'cable-ready:after-set-styles', detail)
   },
 
   // Dataset Mutations .......................................................................................

--- a/lib/cable_ready/channel.rb
+++ b/lib/cable_ready/channel.rb
@@ -187,6 +187,10 @@ module CableReady
       add_operation(:set_style, options)
     end
 
+    def set_styles(options = {})
+      add_operation(:set_styles, options)
+    end
+
     def set_dataset_property(options = {})
       add_operation(:set_dataset_property, options)
     end


### PR DESCRIPTION
This adds a `setStyles` operation that allows for setting multiple style attributes at once on an element. This actually loops through and delegates each entry to the `setStyle` operation.

For example, we can set background and color at once:

```ruby
cable_ready["MyChannel"].set_styles(
  selector: "string", # required - string containing a CSS selector or XPath expression
  styles: {
    background: "red",
    color: "white"
  }
)
```

Depending on browser compatibility targets / goals, we could shorten this by one line using `Object.entries` instead. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries