### PR TITLE
broadcast_to method

### DIFF
--- a/lib/cable_ready/channel.rb
+++ b/lib/cable_ready/channel.rb
@@ -2,7 +2,7 @@
 
 module CableReady
   class Channel
-    attr_reader :name, :operations
+    attr_reader :identifier, :operations
 
     # Example Operations Payload:
     #
@@ -119,8 +119,8 @@ module CableReady
     #     value:    "string"
     #   }, ...],
     # }
-    def initialize(name)
-      @name = name
+    def initialize(identifier)
+      @identifier = identifier
       @operations = stub
     end
 
@@ -131,14 +131,14 @@ module CableReady
     def broadcast
       operations.select! { |_, list| list.present? }
       operations.deep_transform_keys! { |key| key.to_s.camelize(:lower) }
-      ActionCable.server.broadcast name, "cableReady" => true, "operations" => operations
+      ActionCable.server.broadcast identifier, "cableReady" => true, "operations" => operations
       clear
     end
 
-    def broadcast_to(channel, model)
+    def broadcast_to(model)
       operations.select! { |_, list| list.present? }
       operations.deep_transform_keys! { |key| key.to_s.camelize(:lower) }
-      channel.constantize.broadcast_to model, "cableReady" => true, "operations" => operations
+      identifier.broadcast_to model, "cableReady" => true, "operations" => operations
       clear
     end
 

--- a/lib/cable_ready/channel.rb
+++ b/lib/cable_ready/channel.rb
@@ -124,22 +124,22 @@ module CableReady
       @operations = stub
     end
 
-    def clear
+    def reset
       @operations = stub
     end
 
-    def broadcast
+    def broadcast(clear)
       operations.select! { |_, list| list.present? }
       operations.deep_transform_keys! { |key| key.to_s.camelize(:lower) }
       ActionCable.server.broadcast identifier, "cableReady" => true, "operations" => operations
-      clear
+      reset if clear
     end
 
-    def broadcast_to(model)
+    def broadcast_to(model, clear)
       operations.select! { |_, list| list.present? }
       operations.deep_transform_keys! { |key| key.to_s.camelize(:lower) }
       identifier.broadcast_to model, "cableReady" => true, "operations" => operations
-      clear
+      reset if clear
     end
 
     def set_cookie(value)

--- a/lib/cable_ready/channel.rb
+++ b/lib/cable_ready/channel.rb
@@ -127,6 +127,13 @@ module CableReady
       clear
     end
 
+    def broadcast_to(channel, model)
+      operations.select! { |_, list| list.present? }
+      operations.deep_transform_keys! { |key| key.to_s.camelize(:lower) }
+      channel.constantize.broadcast_to model, "cableReady" => true, "operations" => operations
+      clear
+    end
+
     def set_cookie(value)
       add_operation(:set_cookie, {cookie: value})
     end

--- a/lib/cable_ready/channels.rb
+++ b/lib/cable_ready/channels.rb
@@ -12,23 +12,23 @@ module CableReady
       @channels[identifier] ||= CableReady::Channel.new(identifier)
     end
 
-    def broadcast(*identifiers)
+    def broadcast(*identifiers, clear: true)
       @channels.values
         .reject { |channel| identifiers.any? && identifiers.exclude?(channel.identifier) }
         .select { |channel| channel.identifier.is_a?(String) }
         .tap do |channels|
-          channels.each(&:broadcast)
-          channels.each { |channel| @channels.except!(channel.identifier) }
+          channels.each { |channel| @channels[channel.identifier].broadcast(clear) }
+          channels.each { |channel| @channels.except!(channel.identifier) if clear }
         end
     end
 
-    def broadcast_to(model, *identifiers)
+    def broadcast_to(model, *identifiers, clear: true)
       @channels.values
         .reject { |channel| identifiers.any? && identifiers.exclude?(channel.identifier) }
         .reject { |channel| channel.identifier.is_a?(String) }
         .tap do |channels|
-          channels.each { |channel| @channels[channel.identifier].broadcast_to(model) }
-          channels.each { |channel| @channels.except!(channel.identifier) }
+          channels.each { |channel| @channels[channel.identifier].broadcast_to(model, clear) }
+          channels.each { |channel| @channels.except!(channel.identifier) if clear }
         end
     end
   end

--- a/lib/cable_ready/channels.rb
+++ b/lib/cable_ready/channels.rb
@@ -16,23 +16,19 @@ module CableReady
       @channels = {}
     end
 
-    def broadcast(identifier = nil)
-      if identifier
-        @channels[identifier].broadcast
-      else
-        @channels.values.select { |channel| channel.identifier.is_a?(String) }.each(&:broadcast)
-      end
+    def broadcast(*identifiers)
+      @channels.values
+        .reject { |channel| identifiers.any? && identifiers.exclude?(channel.identifier) }
+        .select { |channel| channel.identifier.is_a?(String) }
+        .each(&:broadcast)
       clear
     end
 
-    def broadcast_to(model, identifier = nil)
-      if identifier
-        @channels[identifier].broadcast_to model
-      else
-        @channels.values.reject { |channel| channel.identifier.is_a?(String) }.each do |channel|
-          @channels[channel.identifier].broadcast_to model
-        end
-      end
+    def broadcast_to(model, *identifiers)
+      @channels.values
+        .reject { |channel| identifiers.any? && identifiers.exclude?(channel.identifier) }
+        .reject { |channel| channel.identifier.is_a?(String) }
+        .each { |channel| @channels[channel.identifier].broadcast_to model }
       clear
     end
   end

--- a/lib/cable_ready/channels.rb
+++ b/lib/cable_ready/channels.rb
@@ -14,8 +14,19 @@ module CableReady
       @channels = {}
     end
 
-    def broadcast
-      @channels.values.map(&:broadcast)
+    def broadcast(channel = nil)
+      channel ? @channels[channel].send(:broadcast) : @channels.values.each(&:broadcast)
+      clear
+    end
+
+    def broadcast_to(model, channel = nil)
+      if channel
+        @channels[channel].send(:broadcast_to, channel, model)
+      else
+        @channels.keys.each do |key|
+          @channels[key].send(:broadcast_to, key, model)
+        end
+      end
       clear
     end
   end

--- a/lib/cable_ready/channels.rb
+++ b/lib/cable_ready/channels.rb
@@ -8,25 +8,29 @@ module CableReady
       @channels = {}
     end
 
-    def [](channel_name)
-      @channels[channel_name] ||= CableReady::Channel.new(channel_name)
+    def [](identifier)
+      @channels[identifier] ||= CableReady::Channel.new(identifier)
     end
 
     def clear
       @channels = {}
     end
 
-    def broadcast(channel = nil)
-      channel ? @channels[channel].send(:broadcast) : @channels.values.each(&:broadcast)
+    def broadcast(identifier = nil)
+      if identifier
+        @channels[identifier].send(:broadcast)
+      else
+        @channels.values.select { |channel| channel.identifier.is_a?(String) }.each(&:broadcast)
+      end
       clear
     end
 
-    def broadcast_to(model, channel = nil)
-      if channel
-        @channels[channel].send(:broadcast_to, channel, model)
+    def broadcast_to(model, identifier = nil)
+      if identifier
+        @channels[identifier].send(:broadcast_to, model)
       else
-        @channels.keys.each do |key|
-          @channels[key].send(:broadcast_to, key, model)
+        @channels.values.reject { |channel| channel.identifier.is_a?(String) }.each do |channel|
+          @channels[channel.identifier].send(:broadcast_to, model)
         end
       end
       clear

--- a/lib/cable_ready/channels.rb
+++ b/lib/cable_ready/channels.rb
@@ -12,24 +12,24 @@ module CableReady
       @channels[identifier] ||= CableReady::Channel.new(identifier)
     end
 
-    def clear
-      @channels = {}
-    end
-
     def broadcast(*identifiers)
       @channels.values
         .reject { |channel| identifiers.any? && identifiers.exclude?(channel.identifier) }
         .select { |channel| channel.identifier.is_a?(String) }
-        .each(&:broadcast)
-      clear
+        .tap do |channels|
+          channels.each(&:broadcast)
+          channels.each { |channel| @channels.except!(channel.identifier) }
+        end
     end
 
     def broadcast_to(model, *identifiers)
       @channels.values
         .reject { |channel| identifiers.any? && identifiers.exclude?(channel.identifier) }
         .reject { |channel| channel.identifier.is_a?(String) }
-        .each { |channel| @channels[channel.identifier].broadcast_to model }
-      clear
+        .tap do |channels|
+          channels.each { |channel| @channels[channel.identifier].broadcast_to(model) }
+          channels.each { |channel| @channels.except!(channel.identifier) }
+        end
     end
   end
 end

--- a/lib/cable_ready/channels.rb
+++ b/lib/cable_ready/channels.rb
@@ -18,7 +18,7 @@ module CableReady
 
     def broadcast(identifier = nil)
       if identifier
-        @channels[identifier].send(:broadcast)
+        @channels[identifier].broadcast
       else
         @channels.values.select { |channel| channel.identifier.is_a?(String) }.each(&:broadcast)
       end
@@ -27,10 +27,10 @@ module CableReady
 
     def broadcast_to(model, identifier = nil)
       if identifier
-        @channels[identifier].send(:broadcast_to, model)
+        @channels[identifier].broadcast_to model
       else
         @channels.values.reject { |channel| channel.identifier.is_a?(String) }.each do |channel|
-          @channels[channel.identifier].send(:broadcast_to, model)
+          @channels[channel.identifier].broadcast_to model
         end
       end
       clear


### PR DESCRIPTION
CableReady::Channels exposes a public `broadcast_to(resource)` method, which is used to broadcast to an ActionCable channel which makes use of the `stream_for` method. When using `broadcast_to`, we pass the channel constant instead of a String-based identifier.

```ruby
class DocumentChannel < ApplicationCable::Channel
  def subscribed
    stream_for Document.find(params[:document_id])
  end
end

class Document< ApplicationRecord
  include CableReady::Broadcaster
  after_save do
    cable_ready[DocumentChannel].morph({selector: "#document", html: self.content})
    cable_ready.broadcast_to(self)
  end
end
```

A resource must be passed to the broadcast_to method. ActionCable builds a subscription handle based on the name of the channel and a unique hash of the resource.

When using CableReady, it is possible to have multiple identifiers "on the go" at one time, collecting operations to be run.

Both `broadcast` and `broadcast_to` methods to support an optional identifiers parameter **splat** (h/t: @StephenFiser). Default behaviour is unchanged from current behaviour, which is that all channels are broadcast one at a time. You can pass zero, one or several identifiers.

```ruby
cable_ready.broadcast_to User.find(1), FooChannel, BarChannel
```

`broadcast` will ignore Channel constant identifiers. `broadcast_to` will ignore String identifiers. This means you can have String and Channel identifiers "on the go" at the same time, and they will not conflict.

```ruby
cable_ready['test1'].morph()
cable_ready['test2'].morph()
cable_ready[FooChannel].morph()
cable_ready[BarChannel].morph()

cable_ready.broadcast # broadcasts to test1 and test2
cable_ready.broadcast('test1') # broadcasts to test1
cable_ready.broadcast(FooChannel) # ignored

cable_ready.broadcast_to(Foo.find(1)) # broadcasts to foo:Z2lkOi8vdGhlLWRlcGFubmV1ci9Qcm9wb3NhbC8x AND bar:Z2lkOi8vdGhlLWRlcGFubmV1ci9Qcm9wb3NhbC8x which is valid but probably not what you want
cable_ready.broadcast_to(Foo.find(1), FooChannel) # broadcasts to foo:Z2lkOi8vdGhlLWRlcGFubmV1ci9Qcm9wb3NhbC8x
cable_ready.broadcast_to(Foo.find(1)) # broadcasts to foo:Z2lkOi8vdGhlLWRlcGFubmV1ci9Qcm9wb3NhbC8x AND bar:Z2lkOi8vdGhlLWRlcGFubmV1ci9Qcm9wb3NhbC8x which is valid but probably not what you want
cable_ready.broadcast_to(Foo.find(1), FooChannel, BarChannel) # broadcasts to foo:Z2lkOi8vdGhlLWRlcGFubmV1ci9Qcm9wb3NhbC8x AND bar:Z2lkOi8vdGhlLWRlcGFubmV1ci9Qcm9wb3NhbC8x which is valid but probably not what you want
cable_ready.broadcast_to('test1') # ignored
```

Finally, both `broadcast` and `broadcast_to` now have an optional named last parameter called `clear`, which defaults to `true`. Setting it to `false` prevents CableReady from clearing the channel operations data after a broadcast, allowing it to potentially be sent multiple times or to multiple resources.

```ruby
cable_ready[ImageChannel].morph()
cable_ready.broadcast_to(image1, clear: false)
cable_ready.broadcast_to(image2) # broadcasts the same morph to image2
```