### PR TITLE
Feature/broadcast options

### DIFF
--- a/lib/cable_ready/channel.rb
+++ b/lib/cable_ready/channel.rb
@@ -111,10 +111,10 @@ module CableReady
     #     value:    "string"
     #   }, ...],
     # }
-    def initialize(name)
+    def initialize(name, options = {})
       @name = name
       @operations = stub
-      @options = {}
+      @options = options
     end
 
     def clear
@@ -190,10 +190,6 @@ module CableReady
 
     def set_dataset_property(options = {})
       add_operation(:set_dataset_property, options)
-    end
-
-    def add_option(key, value)
-      @options[key] = value
     end
 
     private

--- a/lib/cable_ready/channel.rb
+++ b/lib/cable_ready/channel.rb
@@ -120,10 +120,10 @@ module CableReady
       @operations = stub
     end
 
-    def broadcast
+    def broadcast(options = {})
       operations.select! { |_, list| list.present? }
       operations.deep_transform_keys! { |key| key.to_s.camelize(:lower) }
-      ActionCable.server.broadcast name, "cableReady" => true, "operations" => operations
+      ActionCable.server.broadcast name, "cableReady" => true, "operations" => operations, "options" => options
       clear
     end
 

--- a/lib/cable_ready/channel.rb
+++ b/lib/cable_ready/channel.rb
@@ -111,10 +111,10 @@ module CableReady
     #     value:    "string"
     #   }, ...],
     # }
-    def initialize(name, options = {})
+    def initialize(name)
       @name = name
       @operations = stub
-      @options = options
+      @options = {}
     end
 
     def clear
@@ -190,6 +190,10 @@ module CableReady
 
     def set_dataset_property(options = {})
       add_operation(:set_dataset_property, options)
+    end
+
+    def add_option(key, value)
+      @options[key] = value
     end
 
     private

--- a/lib/cable_ready/channel.rb
+++ b/lib/cable_ready/channel.rb
@@ -1,6 +1,6 @@
 module CableReady
   class Channel
-    attr_reader :name, :operations
+    attr_reader :name, :operations, :options
 
     # Example Operations Payload:
     #
@@ -111,16 +111,17 @@ module CableReady
     #     value:    "string"
     #   }, ...],
     # }
-    def initialize(name)
+    def initialize(name, options = {})
       @name = name
       @operations = stub
+      @options = options
     end
 
     def clear
       @operations = stub
     end
 
-    def broadcast(options = {})
+    def broadcast
       operations.select! { |_, list| list.present? }
       operations.deep_transform_keys! { |key| key.to_s.camelize(:lower) }
       ActionCable.server.broadcast name, "cableReady" => true, "operations" => operations, "options" => options

--- a/lib/cable_ready/channels.rb
+++ b/lib/cable_ready/channels.rb
@@ -6,8 +6,8 @@ module CableReady
       @channels = {}
     end
 
-    def [](channel_name)
-      @channels[channel_name] ||= CableReady::Channel.new(channel_name)
+    def [](channel_name, options = {})
+      @channels[channel_name] ||= CableReady::Channel.new(channel_name, options)
     end
 
     def clear

--- a/lib/cable_ready/channels.rb
+++ b/lib/cable_ready/channels.rb
@@ -6,8 +6,8 @@ module CableReady
       @channels = {}
     end
 
-    def [](channel_name, options = {})
-      @channels[channel_name] ||= CableReady::Channel.new(channel_name, options)
+    def [](channel_name)
+      @channels[channel_name] ||= CableReady::Channel.new(channel_name)
     end
 
     def clear

--- a/lib/cable_ready/version.rb
+++ b/lib/cable_ready/version.rb
@@ -1,3 +1,3 @@
 module CableReady
-  VERSION = "4.1.3"
+  VERSION = "4.1.4"
 end

--- a/lib/cable_ready/version.rb
+++ b/lib/cable_ready/version.rb
@@ -1,3 +1,3 @@
 module CableReady
-  VERSION = "4.1.4"
+  VERSION = "4.1.3"
 end

--- a/lib/cable_ready/version.rb
+++ b/lib/cable_ready/version.rb
@@ -1,3 +1,3 @@
 module CableReady
-  VERSION = "4.1.2"
+  VERSION = "4.1.3"
 end


### PR DESCRIPTION
This change would allow me to be able to do something like:

```ruby
html = ...
cable_ready["room_channel_#{message.room_id}"].insert_adjacent_html(
  selector: '#messages',
  html: html
)
cable_ready["room_channel_#{message.room_id}"].add_option('user_id', message.user_id)
cable_ready.broadcast
```

See this for context: https://youtu.be/p0p9c_WmnLc

Essentially, I'm doing different things to the UI depending on whether or not I'm the one who posted the message (e.g. text appears on left or right side of screen). I need an easy way to access a user ID for conditional logic even if all of the DOM updates come through CableReady.