### PR TITLE
Customize operations via initializer

### DIFF
--- a/javascript/cable_ready.js
+++ b/javascript/cable_ready.js
@@ -99,7 +99,10 @@ const DOMOperations = {
   // Cookies .................................................................................................
 
   setCookie: config => {
-    document.cookie = config.cookie
+    const { element, cookie } = config
+    dispatch(element, 'cable-ready:before-set-cookie', config)
+    document.cookie = cookie
+    dispatch(element, 'cable-ready:after-set-cookie', config)
   },
 
   // DOM Events ..............................................................................................

--- a/lib/cable_ready/broadcaster.rb
+++ b/lib/cable_ready/broadcaster.rb
@@ -7,7 +7,7 @@ module CableReady
     extend ::ActiveSupport::Concern
 
     def cable_ready
-      @cable_ready_channels ||= CableReady::Channels.new
+      CableReady::Channels.instance
     end
   end
 end

--- a/lib/cable_ready/channel.rb
+++ b/lib/cable_ready/channel.rb
@@ -8,14 +8,14 @@ module CableReady
       @name = name
       @tools = tools
       @operations = stub
-      
+
       tools.each do |tool|
         define_singleton_method tool do |options = {}|
           add_operation tool, options
         end
       end
     end
-    
+
     def broadcast
       operations.select! { |_, list| list.present? }
       operations.deep_transform_keys! { |key| key.to_s.camelize(:lower) }
@@ -31,9 +31,8 @@ module CableReady
     end
 
     def stub
-      tools.inject({}) do |hash, tool|
+      tools.each_with_object({}) do |tool, hash|
         hash[tool] = []
-        hash
       end
     end
   end

--- a/lib/cable_ready/channel.rb
+++ b/lib/cable_ready/channel.rb
@@ -2,209 +2,25 @@
 
 module CableReady
   class Channel
-    attr_reader :name, :operations
+    attr_reader :name, :operations, :tools
 
-    # Example Operations Payload:
-    #
-    # {
-    #   # Cookies .....................................................................................................
-    #
-    #   set_cookie: [
-    #     {cookie: "example=value; path=/; expires=Sat, 07 Mar 2020 16:19:19 GMT"},
-    #     ...
-    #   ]
-    #
-    #   # DOM Events ..................................................................................................
-    #
-    #   dispatch_event: [{
-    #     name:     "string",
-    #     detail:   "object",
-    #     selector: "string",
-    #   }, ...],
-    #
-    #   # Element Mutations ...........................................................................................
-    #
-    #   morph: [{
-    #     selector:      "string",
-    #     html:          "string"
-    #     children_only:  true|false,
-    #     permanent_attribute_name: "string",
-    #     focus_selector: "string",
-    #   }, ...],
-    #
-    #   inner_html: [{
-    #     selector:      "string",
-    #     focus_selector: "string",
-    #     html:          "string"
-    #   }, ...],
-    #
-    #   outer_html: [{
-    #     selector:      "string",
-    #     focus_selector: "string",
-    #     html:          "string"
-    #   }, ...],
-    #
-    #   text_content: [{
-    #     selector: "string",
-    #     text:     "string"
-    #   }, ...]
-    #
-    #   insert_adjacent_html: [{
-    #     selector:      "string",
-    #     focus_selector: "string",
-    #     position:      "string",
-    #     html:          "string"
-    #   }, ...],
-    #
-    #   insert_adjacent_text: [{
-    #     selector: "string",
-    #     position: "string",
-    #     text:     "string"
-    #   }, ...],
-    #
-    #   remove: [{
-    #     selector:      "string",
-    #     focus_selector: "string,
-    #   }, ...],
-    #
-    #   set_property: [{
-    #     name:     "string",
-    #     selector: "string",
-    #     value:    "string"
-    #   }, ...],
-    #
-    #   set_value: [{
-    #     selector: "string",
-    #     value:    "string"
-    #   }, ...],
-    #
-    #   # Attribute Mutations .........................................................................................
-    #
-    #   set_attribute: [{
-    #     selector: "string",
-    #     name:     "string",
-    #     value:    "string"
-    #   }, ...],
-    #
-    #   remove_attribute: [{
-    #     selector: "string",
-    #     name:     "string"
-    #   }, ...],
-    #
-    #   # CSS Class Mutations .........................................................................................
-    #
-    #   add_css_class: [{
-    #     selector: "string",
-    #     name:     "string"
-    #   }, ...],
-    #
-    #   remove_css_class: [{
-    #     selector: "string",
-    #     name:     "string"
-    #   }, ...],
-    #
-    #   # Style Mutations ...........................................................................................
-    #
-    #   set_style: [{
-    #     selector: "string",
-    #     name:     "string",
-    #     value:    "string"
-    #   }, ...],
-    #
-    #   # Dataset Mutations ...........................................................................................
-    #
-    #   set_dataset_property: [{
-    #     selector: "string",
-    #     name:     "string",
-    #     value:    "string"
-    #   }, ...],
-    # }
-    def initialize(name)
+    def initialize(name, tools)
       @name = name
+      @tools = tools
       @operations = stub
+      
+      tools.each do |tool|
+        define_singleton_method tool do |options = {}|
+          add_operation tool, options
+        end
+      end
     end
-
-    def clear
-      @operations = stub
-    end
-
+    
     def broadcast
       operations.select! { |_, list| list.present? }
       operations.deep_transform_keys! { |key| key.to_s.camelize(:lower) }
       ActionCable.server.broadcast name, "cableReady" => true, "operations" => operations
-      clear
-    end
-
-    def set_cookie(value)
-      add_operation(:set_cookie, {cookie: value})
-    end
-
-    def dispatch_event(options = {})
-      add_operation(:dispatch_event, options)
-    end
-
-    def morph(options = {})
-      add_operation(:morph, options)
-    end
-
-    def inner_html(options = {})
-      add_operation(:inner_html, options)
-    end
-
-    def outer_html(options = {})
-      add_operation(:outer_html, options)
-    end
-
-    def text_content(options = {})
-      add_operation(:text_content, options)
-    end
-
-    def insert_adjacent_html(options = {})
-      add_operation(:insert_adjacent_html, options)
-    end
-
-    def insert_adjacent_text(options = {})
-      add_operation(:insert_adjacent_text, options)
-    end
-
-    def remove(options = {})
-      add_operation(:remove, options)
-    end
-
-    def set_property(options = {})
-      add_operation(:set_property, options)
-    end
-
-    def set_value(options = {})
-      add_operation(:set_value, options)
-    end
-
-    def set_attribute(options = {})
-      add_operation(:set_attribute, options)
-    end
-
-    def remove_attribute(options = {})
-      add_operation(:remove_attribute, options)
-    end
-
-    def add_css_class(options = {})
-      add_operation(:add_css_class, options)
-    end
-
-    def remove_css_class(options = {})
-      add_operation(:remove_css_class, options)
-    end
-
-    def set_style(options = {})
-      add_operation(:set_style, options)
-    end
-
-    def set_styles(options = {})
-      add_operation(:set_styles, options)
-    end
-
-    def set_dataset_property(options = {})
-      add_operation(:set_dataset_property, options)
+      @operations = stub
     end
 
     private
@@ -215,25 +31,10 @@ module CableReady
     end
 
     def stub
-      {
-        add_css_class: [],
-        dispatch_event: [],
-        inner_html: [],
-        insert_adjacent_html: [],
-        insert_adjacent_text: [],
-        morph: [],
-        outer_html: [],
-        remove: [],
-        remove_attribute: [],
-        remove_css_class: [],
-        set_attribute: [],
-        set_cookie: [],
-        set_dataset_property: [],
-        set_style: [],
-        set_property: [],
-        set_value: [],
-        text_content: []
-      }
+      tools.inject({}) do |hash, tool|
+        hash[tool] = []
+        hash
+      end
     end
   end
 end

--- a/lib/cable_ready/channel.rb
+++ b/lib/cable_ready/channel.rb
@@ -23,7 +23,6 @@ module CableReady
     private
 
     def add_operation(key, options)
-      operations[key] ||= []
       operations[key] << options
     end
   end

--- a/lib/cable_ready/channel.rb
+++ b/lib/cable_ready/channel.rb
@@ -7,7 +7,7 @@ module CableReady
     def initialize(identifier, available_operations)
       @identifier = identifier
       @available_operations = available_operations
-      @operations = Hash.new { |hash, operation| hash[operation] = [] }
+      reset
       available_operations.each do |available_operation, implementation|
         define_singleton_method available_operation, &implementation
       end
@@ -17,20 +17,24 @@ module CableReady
       operations.select! { |_, list| list.present? }
       operations.deep_transform_keys! { |key| key.to_s.camelize(:lower) }
       ActionCable.server.broadcast identifier, "cableReady" => true, "operations" => operations
-      @operations = Hash.new { |hash, operation| hash[operation] = [] } if clear
+      reset if clear
     end
 
     def broadcast_to(model, clear)
       operations.select! { |_, list| list.present? }
       operations.deep_transform_keys! { |key| key.to_s.camelize(:lower) }
       identifier.broadcast_to model, "cableReady" => true, "operations" => operations
-      @operations = Hash.new { |hash, operation| hash[operation] = [] } if clear
+      reset if clear
     end
 
     private
 
     def add_operation(key, options)
       operations[key] << options
+    end
+
+    def reset
+      @operations = Hash.new { |hash, operation| hash[operation] = [] }
     end
   end
 end

--- a/lib/cable_ready/channel.rb
+++ b/lib/cable_ready/channel.rb
@@ -7,8 +7,7 @@ module CableReady
     def initialize(name, available_operations)
       @name = name
       @available_operations = available_operations
-      @operations = stub
-
+      @operations = Hash.new { |hash, operation| hash[operation] = [] }
       available_operations.each do |available_operation, implementation|
         define_singleton_method available_operation, &implementation
       end
@@ -18,7 +17,7 @@ module CableReady
       operations.select! { |_, list| list.present? }
       operations.deep_transform_keys! { |key| key.to_s.camelize(:lower) }
       ActionCable.server.broadcast name, "cableReady" => true, "operations" => operations
-      @operations = stub
+      @operations = Hash.new { |hash, operation| hash[operation] = [] }
     end
 
     private
@@ -26,12 +25,6 @@ module CableReady
     def add_operation(key, options)
       operations[key] ||= []
       operations[key] << options
-    end
-
-    def stub
-      available_operations.each_with_object({}) do |available_operation, hash|
-        hash[available_operation] = []
-      end
     end
   end
 end

--- a/lib/cable_ready/channel.rb
+++ b/lib/cable_ready/channel.rb
@@ -9,10 +9,8 @@ module CableReady
       @available_operations = available_operations
       @operations = stub
 
-      available_operations.each do |available_operation|
-        define_singleton_method available_operation do |options = {}|
-          add_operation available_operation, options
-        end
+      available_operations.each do |available_operation, implementation|
+        define_singleton_method available_operation, &implementation
       end
     end
 

--- a/lib/cable_ready/channel.rb
+++ b/lib/cable_ready/channel.rb
@@ -30,7 +30,7 @@ module CableReady
 
     def stub
       available_operations.each_with_object({}) do |available_operation, hash|
-        hash[available_operations] = []
+        hash[available_operation] = []
       end
     end
   end

--- a/lib/cable_ready/channel.rb
+++ b/lib/cable_ready/channel.rb
@@ -2,16 +2,16 @@
 
 module CableReady
   class Channel
-    attr_reader :name, :operations, :tools
+    attr_reader :name, :operations, :available_operations
 
-    def initialize(name, tools)
+    def initialize(name, available_operations)
       @name = name
-      @tools = tools
+      @available_operations = available_operations
       @operations = stub
 
-      tools.each do |tool|
-        define_singleton_method tool do |options = {}|
-          add_operation tool, options
+      available_operations.each do |available_operation|
+        define_singleton_method available_operation do |options = {}|
+          add_operation available_operation, options
         end
       end
     end
@@ -31,8 +31,8 @@ module CableReady
     end
 
     def stub
-      tools.each_with_object({}) do |tool, hash|
-        hash[tool] = []
+      available_operations.each_with_object({}) do |available_operation, hash|
+        hash[available_operations] = []
       end
     end
   end

--- a/lib/cable_ready/channels.rb
+++ b/lib/cable_ready/channels.rb
@@ -14,7 +14,25 @@ module CableReady
     def initialize
       @channels = {}
       @operations = {}
-      [:add_css_class, :dispatch_event, :inner_html, :insert_adjacent_html, :insert_adjacent_text, :morph, :outer_html, :remove, :remove_attribute, :remove_css_class, :set_attribute, :set_cookie, :set_dataset_property, :set_property, :set_style, :set_styles, :set_value].each do |operation|
+      %i[
+        add_css_class
+        dispatch_event
+        inner_html
+        insert_adjacent_html
+        insert_adjacent_text
+        morph
+        outer_html
+        remove
+        remove_attribute
+        remove_css_class
+        set_attribute
+        set_cookie
+        set_dataset_property
+        set_property
+        set_style
+        set_styles
+        set_value
+      ].each do |operation|
         add_operation operation
       end
     end

--- a/lib/cable_ready/channels.rb
+++ b/lib/cable_ready/channels.rb
@@ -21,7 +21,7 @@ module CableReady
     end
 
     def [](channel_name)
-      @channels[channel_name] ||= CableReady::Channel.new(channel_name, tools)
+      @channels[channel_name] ||= CableReady::Channel.new(channel_name, tools.uniq)
     end
 
     def clear

--- a/lib/cable_ready/channels.rb
+++ b/lib/cable_ready/channels.rb
@@ -5,7 +5,7 @@ require_relative "channel"
 module CableReady
   class Channels
     include Singleton
-    attr_accessor :tools
+    attr_accessor :operations
 
     def self.configure
       yield CableReady::Channels.instance if block_given?
@@ -13,15 +13,15 @@ module CableReady
 
     def initialize
       @channels = {}
-      @tools = [:add_css_class, :dispatch_event, :inner_html, :insert_adjacent_html, :insert_adjacent_text, :morph, :outer_html, :remove, :remove_attribute, :remove_css_class, :set_attribute, :set_cookie, :set_dataset_property, :set_property, :set_style, :set_styles, :set_value]
+      @operations = [:add_css_class, :dispatch_event, :inner_html, :insert_adjacent_html, :insert_adjacent_text, :morph, :outer_html, :remove, :remove_attribute, :remove_css_class, :set_attribute, :set_cookie, :set_dataset_property, :set_property, :set_style, :set_styles, :set_value]
     end
 
-    def add_tool(tool)
-      @tools << tool.to_sym
+    def add_operation(operation, &implementation)
+      @operations << operation.to_sym
     end
 
     def [](channel_name)
-      @channels[channel_name] ||= CableReady::Channel.new(channel_name, tools.uniq)
+      @channels[channel_name] ||= CableReady::Channel.new(channel_name, operations.uniq)
     end
 
     def clear

--- a/lib/cable_ready/channels.rb
+++ b/lib/cable_ready/channels.rb
@@ -4,12 +4,24 @@ require_relative "channel"
 
 module CableReady
   class Channels
+    include Singleton
+    attr_accessor :tools
+
+    def self.configure
+      yield CableReady::Channels.instance if block_given?
+    end
+
     def initialize
       @channels = {}
+      @tools = [:add_css_class, :dispatch_event, :inner_html, :insert_adjacent_html, :insert_adjacent_text, :morph, :outer_html, :remove, :remove_attribute, :remove_css_class, :set_attribute, :set_cookie, :set_dataset_property, :set_property, :set_style, :set_styles, :set_value]
+    end
+
+    def add_tool(tool)
+      @tools << tool.to_sym
     end
 
     def [](channel_name)
-      @channels[channel_name] ||= CableReady::Channel.new(channel_name)
+      @channels[channel_name] ||= CableReady::Channel.new(channel_name, tools)
     end
 
     def clear

--- a/lib/cable_ready/channels.rb
+++ b/lib/cable_ready/channels.rb
@@ -13,15 +13,18 @@ module CableReady
 
     def initialize
       @channels = {}
-      @operations = [:add_css_class, :dispatch_event, :inner_html, :insert_adjacent_html, :insert_adjacent_text, :morph, :outer_html, :remove, :remove_attribute, :remove_css_class, :set_attribute, :set_cookie, :set_dataset_property, :set_property, :set_style, :set_styles, :set_value]
+      @operations = {}
+      [:add_css_class, :dispatch_event, :inner_html, :insert_adjacent_html, :insert_adjacent_text, :morph, :outer_html, :remove, :remove_attribute, :remove_css_class, :set_attribute, :set_cookie, :set_dataset_property, :set_property, :set_style, :set_styles, :set_value].each do |operation|
+        add_operation operation
+      end    
     end
 
     def add_operation(operation, &implementation)
-      @operations << operation.to_sym
+      @operations[operation] = implementation || ->(options = {}) { add_operation(operation, options) }
     end
 
     def [](channel_name)
-      @channels[channel_name] ||= CableReady::Channel.new(channel_name, operations.uniq)
+      @channels[channel_name] ||= CableReady::Channel.new(channel_name, operations)
     end
 
     def clear

--- a/lib/cable_ready/channels.rb
+++ b/lib/cable_ready/channels.rb
@@ -16,7 +16,7 @@ module CableReady
       @operations = {}
       [:add_css_class, :dispatch_event, :inner_html, :insert_adjacent_html, :insert_adjacent_text, :morph, :outer_html, :remove, :remove_attribute, :remove_css_class, :set_attribute, :set_cookie, :set_dataset_property, :set_property, :set_style, :set_styles, :set_value].each do |operation|
         add_operation operation
-      end    
+      end
     end
 
     def add_operation(operation, &implementation)


### PR DESCRIPTION
I spent a lot of time looking at @n-rodriguez' #43 because I **hate** that he has to monkey patch the library in order to add additional operations. There's been a few moments where we've idly talked about supporting configuration details and also I have long been irritated by the implicit singleton pattern implied in the way we use CableReady::Channels. It turns out that Ruby has a workable singleton module that we can use to start refacting how CR works behind the scenes, allowing for customization.

This PR would allow @n-rodriguez to just create `config/initializers/cable_ready.rb`:

```ruby
CableReady::Channels.configure do |config|
  config.add_operation :notify
end
```

Thanks to @foca, @n-rodriguez also has the option to define the implementation of their new custom operation:

```ruby
CableReady::Channels.configure do |config|
  config.add_operation :notify do |options|
    puts "Eat dirt!"
  end
end
```

Having a list of operations means that the code for `channel.rb` is dramatically more concise, as we can dynamically define everything in a consistent way. Adding a new operation to the library is now just adding a symbol to an array.

This also opens the door to additional future configuration opportunities via the initializer.

All of the function signature comments have been erased as we now have proper project documentation, keeping everything in one place and drastically lowering both tedium and the incident rate of typing errors, as we saw recently with #40.

Note that there is an extremely minor *technically* breaking change which I suspect will only impact CodeFund as it's not even documented, yet: for reasons that are unknown to me (but I assume good intentions) all of the operation method signatures were identical `options = {}` **except for set_cookie** which inexplicably accepted a value string. In order for this to work, anyone using set_cooking would have to update from "string" to {cookie: "string"}. **Technically, we could define a custom implementation for `set_cookie` that would keep the current function signature, but my vote is to move forward with a consistent API for all "factory settings".**