### PR TITLE
Support for multiple CSS classes.

### DIFF
--- a/docs/usage/dom-operations/css-class-mutations.md
+++ b/docs/usage/dom-operations/css-class-mutations.md
@@ -7,7 +7,7 @@ Adds a CSS class to an element. This is a `noop` if the CSS class is already ass
 ```ruby
 cable_ready["MyChannel"].add_css_class(
   selector: "string", # required - string containing a CSS selector or XPath expression
-  name:     "string"  # [null]   - the CSS class to add
+  name:     "string"  # [null]   - string containing the CSS class name to add
 )
 ```
 
@@ -16,7 +16,7 @@ Use an array to sets multiple classes to an element.
 ```ruby
 cable_ready["MyChannel"].add_css_class(
   selector: "string", # required - string containing a CSS selector or XPath expression
-  name:     ["string", "string2"]  # [null]   - the CSS class to add
+  name:     ["string", "string2"]  # [null] - array with the CSS class names to add
 )
 ```
 
@@ -32,7 +32,7 @@ Removes a CSS class from an element.
 ```ruby
 cable_ready["MyChannel"].remove_css_class(
   selector: "string", # required - string containing a CSS selector or XPath expression
-  name:     "string"  # [null]   - the CSS class to remove
+  name:     "string"  # [null]   - string containing the CSS class name to remove
 )
 ```
 
@@ -41,7 +41,7 @@ Use an array to removes multiple classes from an element.
 ```ruby
 cable_ready["MyChannel"].remove_css_class(
   selector: "string", # required - string containing a CSS selector or XPath expression
-  name:     ["string", "string2"]  # [null]   - the CSS class to add
+  name:     ["string", "string2"]  # [null] - array with the CSS class names to remove
 )
 ```
 

--- a/docs/usage/dom-operations/css-class-mutations.md
+++ b/docs/usage/dom-operations/css-class-mutations.md
@@ -11,6 +11,15 @@ cable_ready["MyChannel"].add_css_class(
 )
 ```
 
+Use an array to sets multiple classes to an element.
+
+```ruby
+cable_ready["MyChannel"].add_css_class(
+  selector: "string", # required - string containing a CSS selector or XPath expression
+  name:     ["string", "string2"]  # [null]   - the CSS class to add
+)
+```
+
 ### JavaScript Events
 
 * `cable-ready:before-add-css-class`
@@ -24,6 +33,15 @@ Removes a CSS class from an element.
 cable_ready["MyChannel"].remove_css_class(
   selector: "string", # required - string containing a CSS selector or XPath expression
   name:     "string"  # [null]   - the CSS class to remove
+)
+```
+
+Use an array to removes multiple classes from an element.
+
+```ruby
+cable_ready["MyChannel"].remove_css_class(
+  selector: "string", # required - string containing a CSS selector or XPath expression
+  name:     ["string", "string2"]  # [null]   - the CSS class to add
 )
 ```
 

--- a/javascript/cable_ready.js
+++ b/javascript/cable_ready.js
@@ -69,25 +69,11 @@ const xpathToElement = xpath => {
   ).singleNodeValue
 }
 
-// Assigns one or multiple classes to the appropriate element...
+// Return an array with the class names to be used
 //
-// * element - the element
-// * name - could be a string or an array of strings to add one or multiple classes.
+// * names - could be a string or an array of strings for multiple classes.
 //
-const addClass = (element, name) => {
-  const { classList } = element
-  Array.isArray(name) ? classList.add(...name) : classList.add(name)
-}
-
-// Removes one or multiple classes from the appropriate element...
-//
-// * element - the element
-// * name - could be a string or an array of strings to remove one or multiple classes.
-//
-const removeClass = (element, name) => {
-  const { classList } = element
-  Array.isArray(name) ? classList.remove(...name) : classList.remove(name)
-}
+const getClassNames = names => Array(names).flat()
 
 // Indicates whether or not we should morph an element
 // SEE: https://github.com/patrick-steele-idem/morphdom#morphdomfromnode-tonode-options--node
@@ -244,14 +230,14 @@ const DOMOperations = {
   addCssClass: detail => {
     const { element, name } = detail
     dispatch(element, 'cable-ready:before-add-css-class', detail)
-    addClass(element, name)
+    element.classList.add(...getClassNames(name))
     dispatch(element, 'cable-ready:after-add-css-class', detail)
   },
 
   removeCssClass: detail => {
     const { element, name } = detail
     dispatch(element, 'cable-ready:before-remove-css-class', detail)
-    removeClass(element, name)
+    element.classList.remove(...getClassNames(name))
     dispatch(element, 'cable-ready:after-remove-css-class', detail)
   },
 

--- a/javascript/cable_ready.js
+++ b/javascript/cable_ready.js
@@ -75,7 +75,7 @@ const xpathToElement = xpath => {
 // * name - could be a string or an array of strings to add one or multiple classes.
 //
 const addClass = (element, name) => {
-  const { classList } = element;
+  const { classList } = element
   Array.isArray(name) ? classList.add(...name) : classList.add(name)
 }
 
@@ -85,7 +85,7 @@ const addClass = (element, name) => {
 // * name - could be a string or an array of strings to remove one or multiple classes.
 //
 const removeClass = (element, name) => {
-  const { classList } = element;
+  const { classList } = element
   Array.isArray(name) ? classList.remove(...name) : classList.remove(name)
 }
 

--- a/javascript/cable_ready.js
+++ b/javascript/cable_ready.js
@@ -69,6 +69,26 @@ const xpathToElement = xpath => {
   ).singleNodeValue
 }
 
+// Assigns one or multiple classes to the appropriate element...
+//
+// * element - the element
+// * name - could be a string or an array of strings to add one or multiple classes.
+//
+const addClass = (element, name) => {
+  const { classList } = element;
+  Array.isArray(name) ? classList.add(...name) : classList.add(name)
+}
+
+// Removes one or multiple classes from the appropriate element...
+//
+// * element - the element
+// * name - could be a string or an array of strings to remove one or multiple classes.
+//
+const removeClass = (element, name) => {
+  const { classList } = element;
+  Array.isArray(name) ? classList.remove(...name) : classList.remove(name)
+}
+
 // Indicates whether or not we should morph an element
 // SEE: https://github.com/patrick-steele-idem/morphdom#morphdomfromnode-tonode-options--node
 //
@@ -224,22 +244,14 @@ const DOMOperations = {
   addCssClass: detail => {
     const { element, name } = detail
     dispatch(element, 'cable-ready:before-add-css-class', detail)
-    if (Array.isArray(name)) {
-      element.classList.add(...name)
-    } else {
-      element.classList.add(name)
-    }
+    addClass(element, name)
     dispatch(element, 'cable-ready:after-add-css-class', detail)
   },
 
   removeCssClass: detail => {
     const { element, name } = detail
     dispatch(element, 'cable-ready:before-remove-css-class', detail)
-    if (Array.isArray(name)) {
-      element.classList.remove(...name)
-    } else {
-      element.classList.remove(name)
-    }
+    removeClass(element, name)
     dispatch(element, 'cable-ready:after-remove-css-class', detail)
   },
 

--- a/javascript/cable_ready.js
+++ b/javascript/cable_ready.js
@@ -224,14 +224,22 @@ const DOMOperations = {
   addCssClass: detail => {
     const { element, name } = detail
     dispatch(element, 'cable-ready:before-add-css-class', detail)
-    element.classList.add(name)
+    if (Array.isArray(name)) {
+      element.classList.add(...name)
+    } else {
+      element.classList.add(name)
+    }
     dispatch(element, 'cable-ready:after-add-css-class', detail)
   },
 
   removeCssClass: detail => {
     const { element, name } = detail
     dispatch(element, 'cable-ready:before-remove-css-class', detail)
-    element.classList.remove(name)
+    if (Array.isArray(name)) {
+      element.classList.remove(...name)
+    } else {
+      element.classList.remove(name)
+    }
     dispatch(element, 'cable-ready:after-remove-css-class', detail)
   },
 


### PR DESCRIPTION
Add support to add and remove multiple CSS classes on _addCssClass_ and _removeCssClass_ methods following the [classList](https://developer.mozilla.org/en-US/docs/Web/API/Element/classList) documentation.

For example, you can set "btn btn-light" at once:

```ruby
cable_ready["MyChannel"].add_css_class(
  selector: "string", # required - string containing a CSS selector or XPath expression
  name:     ["btn", "btn-light"]  # [null]   - the CSS class to add
)
```
