### PR TITLE
add dom_id helper

### DIFF
--- a/lib/cable_ready/broadcaster.rb
+++ b/lib/cable_ready/broadcaster.rb
@@ -9,5 +9,9 @@ module CableReady
     def cable_ready
       @cable_ready_channels ||= CableReady::Channels.new
     end
+
+    def dom_id(resource)
+      "##{ActionView::RecordIdentifier.dom_id(resource)}"
+    end
   end
 end


### PR DESCRIPTION
When calling CableReady, it is common to see

`cable_ready['identifier'].morph({selector: "#" + ActionView::RecordIdentifier.dom_id(user)})`

This PR would add a `dom_id(resource)` method to `CableReady::Broadcaster` and allow the following:

`cable_ready['identifier'].morph({selector: dom_id(user)})`

What's not to love?