### PR TITLE
Dom id signature fix

### DIFF
--- a/lib/cable_ready/broadcaster.rb
+++ b/lib/cable_ready/broadcaster.rb
@@ -9,5 +9,9 @@ module CableReady
     def cable_ready
       @cable_ready_channels ||= CableReady::Channels.new
     end
+
+    def dom_id(resource)
+      "##{ActionView::RecordIdentifier.dom_id(resource)}"
+    end
   end
 end

--- a/lib/cable_ready/broadcaster.rb
+++ b/lib/cable_ready/broadcaster.rb
@@ -10,8 +10,8 @@ module CableReady
       @cable_ready_channels ||= CableReady::Channels.new
     end
 
-    def dom_id(resource)
-      "##{ActionView::RecordIdentifier.dom_id(resource)}"
+    def dom_id(record, prefix = nil)
+      "##{ActionView::RecordIdentifier.dom_id(record, prefix)}"
     end
   end
 end


### PR DESCRIPTION
I goofed - dom_id takes an important second parameter, prefix:

https://apidock.com/rails/ActionView/RecordIdentifier/dom_id

This PR is like #50 but better. It maintains the function signature 1:1.