### PR TITLE
text_content is missing from 4.3.0.pre0

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -42,6 +42,8 @@ CableReady supports the following DOM operations that can be triggered from serv
 14. [setStyle](usage/dom-operations/css-class-mutations.md#setstyle)
 15. [setStyles](usage/dom-operations/css-class-mutations.md#setstyles)
 16. [setDatasetProperty](usage/dom-operations/dataset-mutations.md#setdatasetproperty)
+17. [textContent](usage/dom-operations/element-mutations.md#textcontent)
+18. [setCookie](usage/dom-operations/cookies.md#setcookie)
 
 As with other new tools, the potential use cases are only limited by your imagination. For example, CableReady provides the foundation for incredible libraries like [StimulusReflex](https://docs.stimulusreflex.com).
 

--- a/docs/usage/dom-operations/README.md
+++ b/docs/usage/dom-operations/README.md
@@ -21,6 +21,7 @@ All DOM mutations have corresponding `before/after` events triggered on `documen
 * [morph](element-mutations.md#morph)
 * [innerHTML](element-mutations.md#innerhtml)
 * [outerHTML](element-mutations.md#outerhtml)
+* [textContent](element-mutations.md#textcontent)
 * [insertAdjacentHTML](element-mutations.md#insertAdjacentHTML)
 * [insertAdjacentText](element-mutations.md#insertadjacenttext)
 * [remove](element-mutations.md#remove)

--- a/docs/usage/dom-operations/cookies.md
+++ b/docs/usage/dom-operations/cookies.md
@@ -1,0 +1,14 @@
+# Cookies
+
+## [setCookie](https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie)
+
+{% hint style="info" %}
+Writes a cookie to the cookie store.
+{% endhint %}
+
+```ruby
+cable_ready["MyChannel"].set_cookie(
+  cookie:     "string" # "example=value; path=/; expires=Sat, 07 Mar 2020 16:19:19 GMT"
+)
+```
+

--- a/lib/cable_ready/channels.rb
+++ b/lib/cable_ready/channels.rb
@@ -32,6 +32,7 @@ module CableReady
         set_style
         set_styles
         set_value
+        text_content
       ].each do |operation|
         add_operation operation
       end


### PR DESCRIPTION
Thanks to @julianrubisch who caught that the list of possible operations omitted `text_content`.

This is why pre-releases are so important!