### PR TITLE
Notifications

### DIFF
--- a/javascript/cable_ready.js
+++ b/javascript/cable_ready.js
@@ -102,13 +102,63 @@ const shouldMorph = permanentAttributeName => (fromEl, toEl) => {
 // Morphdom Callbacks ........................................................................................
 
 const DOMOperations = {
+  // Notifications
+
+  consoleLog: config => {
+    const { message, level } = config
+    level && ['warn', 'info', 'error'].includes(level)
+      ? console[level](message)
+      : console.log(message)
+  },
+
+  dispatchAlert: config => {
+    const { message } = config
+    dispatch(document, 'cable-ready:before-dispatch-alert', config)
+    alert(message)
+    dispatch(document, 'cable-ready:after-dispatch-alert', config)
+  },
+
+  dispatchConfirm: config => {
+    const { message } = config
+    dispatch(document, 'cable-ready:before-dispatch-confirm', config)
+    const result = confirm(message)
+    dispatch(document, 'cable-ready:after-dispatch-confirm', {
+      ...config,
+      result
+    })
+  },
+
+  dispatchPrompt: config => {
+    const { message, defaultValue } = config
+    dispatch(document, 'cable-ready:before-dispatch-prompt', config)
+    const result = prompt(message, defaultValue)
+    dispatch(document, 'cable-ready:after-dispatch-prompt', {
+      ...config,
+      result
+    })
+  },
+
+  notification: config => {
+    const { title, options } = config
+    dispatch(document, 'cable-ready:before-notification', config)
+    let permission
+    Notification.requestPermission().then(result => {
+      permission = result
+      if (result === 'granted') new Notification(title || '', options)
+      dispatch(document, 'cable-ready:after-notification', {
+        ...config,
+        permission
+      })
+    })
+  },
+
   // Cookies .................................................................................................
 
   setCookie: config => {
-    const { element, cookie } = config
-    dispatch(element, 'cable-ready:before-set-cookie', config)
+    const { cookie } = config
+    dispatch(document, 'cable-ready:before-set-cookie', config)
     document.cookie = cookie
-    dispatch(element, 'cable-ready:after-set-cookie', config)
+    dispatch(document, 'cable-ready:after-set-cookie', config)
   },
 
   // DOM Events ..............................................................................................

--- a/javascript/cable_ready.js
+++ b/javascript/cable_ready.js
@@ -111,33 +111,6 @@ const DOMOperations = {
       : console.log(message)
   },
 
-  dispatchAlert: config => {
-    const { message } = config
-    dispatch(document, 'cable-ready:before-dispatch-alert', config)
-    alert(message)
-    dispatch(document, 'cable-ready:after-dispatch-alert', config)
-  },
-
-  dispatchConfirm: config => {
-    const { message } = config
-    dispatch(document, 'cable-ready:before-dispatch-confirm', config)
-    const result = confirm(message)
-    dispatch(document, 'cable-ready:after-dispatch-confirm', {
-      ...config,
-      result
-    })
-  },
-
-  dispatchPrompt: config => {
-    const { message, defaultValue } = config
-    dispatch(document, 'cable-ready:before-dispatch-prompt', config)
-    const result = prompt(message, defaultValue)
-    dispatch(document, 'cable-ready:after-dispatch-prompt', {
-      ...config,
-      result
-    })
-  },
-
   notification: config => {
     const { title, options } = config
     dispatch(document, 'cable-ready:before-notification', config)

--- a/lib/cable_ready/channels.rb
+++ b/lib/cable_ready/channels.rb
@@ -16,11 +16,16 @@ module CableReady
       @operations = {}
       %i[
         add_css_class
+        console_log
+        dispatch_alert
+        dispatch_confirm
         dispatch_event
+        dispatch_prompt
         inner_html
         insert_adjacent_html
         insert_adjacent_text
         morph
+        notification
         outer_html
         remove
         remove_attribute

--- a/lib/cable_ready/channels.rb
+++ b/lib/cable_ready/channels.rb
@@ -17,10 +17,7 @@ module CableReady
       %i[
         add_css_class
         console_log
-        dispatch_alert
-        dispatch_confirm
         dispatch_event
-        dispatch_prompt
         inner_html
         insert_adjacent_html
         insert_adjacent_text


### PR DESCRIPTION
# New operations

- consoleLog(message, level)
- notification(title, options)

Before you say, "hey, weren't you complaining about having to write docs?" know that at least I stopped short of creating wrappers around the entire `console` object.

## consoleLog

This sends messages to the browser console. It defaults to `log` level but you can specify `warn` `error` `info` as well. No events are emitted.

## notification

This is the real power-move: this will allow you to deliver desktop native notifications. It asks the user if they Approve or Block in a native popup; if they don't answer, it will ask them again next time. If they approve, you now have a direct route to their brains.

Title is officially required, but I have defaulted it to an empty string.

Options is an object that contains parameters for your popup. The most obviously useful is `body` which is the message below the title. You might also want to specify `icon` which takes a URL to an image. You can even `vibrate` their phone or mark your message as `silent`. [Knock yerself out!](https://developer.mozilla.org/en-US/docs/Web/API/notification/Notification)