### PR TITLE
only pass inner html if childrenOnly is false

### DIFF
--- a/javascript/cable_ready.js
+++ b/javascript/cable_ready.js
@@ -160,8 +160,7 @@ const DOMOperations = {
     })
     const parent = element.parentElement
     const ordinal = Array.from(parent.children).indexOf(element)
-    const toNode = childrenOnly ? template.content : template.innerHTML
-    morphdom(element, toNode, {
+    morphdom(element, childrenOnly ? template.content : template.innerHTML, {
       childrenOnly: !!childrenOnly,
       onBeforeElUpdated: shouldMorph(permanentAttributeName)
     })

--- a/javascript/cable_ready.js
+++ b/javascript/cable_ready.js
@@ -160,7 +160,8 @@ const DOMOperations = {
     })
     const parent = element.parentElement
     const ordinal = Array.from(parent.children).indexOf(element)
-    morphdom(element, template.content, {
+    const toNode = childrenOnly ? template.content : template.innerHTML
+    morphdom(element, toNode, {
       childrenOnly: !!childrenOnly,
       onBeforeElUpdated: shouldMorph(permanentAttributeName)
     })


### PR DESCRIPTION
Okay, so this is the result of a lot of iteration trying to get `children_only: false` to work properly with `data-reflex-permanent`. If we just keep `template.content` when using `children_only: false`, you end up with a number of strange situations, dending on the HTML you're trying to morph. I believe this is due to the differences between fromNode and toNode. This change results in my test project successfully rendering with children_only set to true or false, always respecting the permanent attribute.

I'm not 100% confident about the ramifications of this change, but I'm testing it in my expo app and everything's working as expected for all examples. 


This is related to issue 2 on the discord.

> For reasons we don't currently understand, when you do a :selector morph, it ignores data-reflex-permanent attributes. (If you're familiar with cable_ready.js, shouldMorph just does not fire.) This is confounding and very frustrating. It seems to happen regardless of whether children are replaced.
