### PR TITLE
Add braces to hash parameter to remove warning

### DIFF
--- a/lib/cable_ready/channel.rb
+++ b/lib/cable_ready/channel.rb
@@ -16,14 +16,14 @@ module CableReady
     def broadcast(clear)
       operations.select! { |_, list| list.present? }
       operations.deep_transform_keys! { |key| key.to_s.camelize(:lower) }
-      ActionCable.server.broadcast identifier, "cableReady" => true, "operations" => operations
+      ActionCable.server.broadcast identifier, {"cableReady" => true, "operations" => operations}
       reset if clear
     end
 
     def broadcast_to(model, clear)
       operations.select! { |_, list| list.present? }
       operations.deep_transform_keys! { |key| key.to_s.camelize(:lower) }
-      identifier.broadcast_to model, "cableReady" => true, "operations" => operations
+      identifier.broadcast_to model, {"cableReady" => true, "operations" => operations}
       reset if clear
     end
 


### PR DESCRIPTION
Small change to remove the Ruby 3.0 warning:

```
...cable_ready-4.3.0/lib/cable_ready/channel.rb:19: warning: Passing the keyword argument as the last hash parameter is deprecated
```