### PR TITLE
Provide an async perform method

### DIFF
--- a/javascript/cable_ready.js
+++ b/javascript/cable_ready.js
@@ -329,4 +329,17 @@ const perform = (
   }
 }
 
-export default { perform, isTextInput, DOMOperations }
+const performAsync = (
+  operations,
+  options = { emitMissingElementWarnings: true }
+) => {
+  return new Promise((resolve, reject) => {
+    try {
+      resolve(perform(operations, options))
+    } catch (err) {
+      reject(err)
+    }
+  })
+}
+
+export default { perform, performAsync, isTextInput, DOMOperations }


### PR DESCRIPTION
In certain situations it can be preferable to `await` until morphdom operations are completed asynchronously to free the main thread to do other work. 

One example would be to trigger events that bubble up the DOM without waiting for the morphs to finish. 