### PR TITLE
Add a shared mutex to avoid concurrency issues in Channels

### DIFF
--- a/lib/cable_ready/channels.rb
+++ b/lib/cable_ready/channels.rb
@@ -49,23 +49,33 @@ module CableReady
     end
 
     def broadcast(*identifiers, clear: true)
-      @channels.values
-        .reject { |channel| identifiers.any? && identifiers.exclude?(channel.identifier) }
-        .select { |channel| channel.identifier.is_a?(String) }
-        .tap do |channels|
-          channels.each { |channel| @channels[channel.identifier].broadcast(clear) }
-          channels.each { |channel| @channels.except!(channel.identifier) if clear }
-        end
+      mutex.synchronize do
+        @channels.values
+          .reject { |channel| identifiers.any? && identifiers.exclude?(channel.identifier) }
+          .select { |channel| channel.identifier.is_a?(String) }
+          .tap do |channels|
+            channels.each { |channel| @channels[channel.identifier].broadcast(clear) }
+            channels.each { |channel| @channels.except!(channel.identifier) if clear }
+          end
+      end
     end
 
     def broadcast_to(model, *identifiers, clear: true)
-      @channels.values
-        .reject { |channel| identifiers.any? && identifiers.exclude?(channel.identifier) }
-        .reject { |channel| channel.identifier.is_a?(String) }
-        .tap do |channels|
-          channels.each { |channel| @channels[channel.identifier].broadcast_to(model, clear) }
-          channels.each { |channel| @channels.except!(channel.identifier) if clear }
-        end
+      mutex.synchronize do
+        @channels.values
+          .reject { |channel| identifiers.any? && identifiers.exclude?(channel.identifier) }
+          .reject { |channel| channel.identifier.is_a?(String) }
+          .tap do |channels|
+            channels.each { |channel| @channels[channel.identifier].broadcast_to(model, clear) }
+            channels.each { |channel| @channels.except!(channel.identifier) if clear }
+          end
+      end
+    end
+
+    private
+
+    def mutex
+      @mutex ||= Mutex.new
     end
   end
 end


### PR DESCRIPTION
This resolves the issue discussed in #64 where the @channels object may be modified out-of-sync in a multi-threaded environment, potentially resulting in premature broadcasting or loss of operations before broadcast.