### PR TITLE
use CustomEvent to get IE11 working

### DIFF
--- a/javascript/cable_ready.js
+++ b/javascript/cable_ready.js
@@ -53,9 +53,8 @@ const assignFocus = focusSelector => {
 // * detail - the event detail
 //
 const dispatch = (element, name, detail = {}) => {
-  const init = { bubbles: true, cancelable: true }
-  const evt = new Event(name, init)
-  evt.detail = detail
+  const init = { bubbles: true, cancelable: true, detail: detail }
+  const evt = new CustomEvent(name, init)
   element.dispatchEvent(evt)
 }
 


### PR DESCRIPTION
I was able to get StimulusReflex and CableReady working in IE11.  In addition to a bunch of polyfills (documented [here](https://gist.github.com/existentialmutt/7f32f9d3217d41a2d8bcd4c61aa201ec), I needed to make a small change to cable_ready.js

Event constructor is not supported in IE11 and CustomEvent.detail is a readonly property in the poyfill implementation I used.