### PR TITLE
jquery support

### DIFF
--- a/javascript/cable_ready.js
+++ b/javascript/cable_ready.js
@@ -56,6 +56,7 @@ const dispatch = (element, name, detail = {}) => {
   const init = { bubbles: true, cancelable: true, detail: detail }
   const evt = new CustomEvent(name, init)
   element.dispatchEvent(evt)
+  if (window.jQuery) window.jQuery(element).trigger(name, detail)
 }
 
 const xpathToElement = xpath => {


### PR DESCRIPTION
All calls to `dispatch` would now test for the presence of jQuery, and if present, would initiate a matching jQuery event with the same name and details object.