### PR TITLE
method chaining

### DIFF
--- a/lib/cable_ready/channel.rb
+++ b/lib/cable_ready/channel.rb
@@ -13,24 +13,33 @@ module CableReady
       end
     end
 
-    def broadcast(clear)
+    def channel_broadcast(clear)
       operations.select! { |_, list| list.present? }
       operations.deep_transform_keys! { |key| key.to_s.camelize(:lower) }
       ActionCable.server.broadcast identifier, {"cableReady" => true, "operations" => operations}
       reset if clear
     end
 
-    def broadcast_to(model, clear)
+    def channel_broadcast_to(model, clear)
       operations.select! { |_, list| list.present? }
       operations.deep_transform_keys! { |key| key.to_s.camelize(:lower) }
       identifier.broadcast_to model, {"cableReady" => true, "operations" => operations}
       reset if clear
     end
 
+    def broadcast(clear = true)
+      cable_ready.broadcast(identifier, clear)
+    end
+
+    def broadcast_to(model, clear = true)
+      cable_ready.broadcast_to(model, clear)
+    end
+
     private
 
     def add_operation(key, options)
       operations[key] << options
+      self
     end
 
     def reset

--- a/lib/cable_ready/channel.rb
+++ b/lib/cable_ready/channel.rb
@@ -37,7 +37,7 @@ module CableReady
 
     private
 
-    def add_operation(key, options)
+    def enqueue_operation(key, options)
       operations[key] << options
       self
     end

--- a/lib/cable_ready/channels.rb
+++ b/lib/cable_ready/channels.rb
@@ -43,7 +43,7 @@ module CableReady
     end
 
     def add_operation(operation, &implementation)
-      @operations[operation] = implementation || ->(options = {}) { add_operation(operation, options) }
+      @operations[operation] = implementation || ->(options = {}) { enqueue_operation(operation, options) }
     end
 
     def [](identifier)

--- a/lib/cable_ready/channels.rb
+++ b/lib/cable_ready/channels.rb
@@ -56,7 +56,7 @@ module CableReady
           .reject { |channel| identifiers.any? && identifiers.exclude?(channel.identifier) }
           .select { |channel| channel.identifier.is_a?(String) }
           .tap do |channels|
-            channels.each { |channel| @channels[channel.identifier].broadcast(clear) }
+            channels.each { |channel| @channels[channel.identifier].channel_broadcast(clear) }
             channels.each { |channel| @channels.except!(channel.identifier) if clear }
           end
       end
@@ -68,7 +68,7 @@ module CableReady
           .reject { |channel| identifiers.any? && identifiers.exclude?(channel.identifier) }
           .reject { |channel| channel.identifier.is_a?(String) }
           .tap do |channels|
-            channels.each { |channel| @channels[channel.identifier].broadcast_to(model, clear) }
+            channels.each { |channel| @channels[channel.identifier].channel_broadcast_to(model, clear) }
             channels.each { |channel| @channels.except!(channel.identifier) if clear }
           end
       end


### PR DESCRIPTION
@coderberry requested that CableReady operations be chainable. That was actually so easy, I'm a bit sad we didn't do this all along. I just had to modify `Channel#add_operation` to return `self`.

```ruby
cable_ready["MyChannel"].morph(selector: "body", content: "blah").dispatch_event(name: "boom", detail: {})
```

The logical progression from there was to be able to conclude a chain with `broadcast` or `broadcast_to`. This was a little more complicated, as the `Channel` class already had `broadcast` and `broadcast_to` methods. Arguably, this was unnecessarily confusing and disambiguating to `channel_broadcast` and `channel_broadcast_to` helps make the code easier to follow.

I changed the similarly confusing `Channel#add_operation` to `Channel#enqueue_operation` for similar reasons.

Anyhow, with methods renamed, we now have new `Channel#broadcast` and `Channel#broadcast_to` methods which implicitly pass the current channel identifier and/or model to update so there's no ambiguity about what is being broadcast. `Channel#broadcast` accepts an optional boolean for the `clear` argument, defaulting to `true`. `Channel#broadcast_to` requires a model instance argument and allows the optional boolean for the `clear` argument, again defaulting to `true`.

```ruby
cable_ready["MyChannel"].morph(selector: "body", content: "blah").dispatch_event(name: "boom", detail: {}).broadcast_to(User.find(params[:id]))
```