### PR TITLE
Fix bug related to channel calling broadcast on the singleton

### DIFF
--- a/lib/cable_ready/channel.rb
+++ b/lib/cable_ready/channel.rb
@@ -28,11 +28,11 @@ module CableReady
     end
 
     def broadcast(clear = true)
-      CableReady::Channels.instance.broadcast(identifier, clear)
+      CableReady::Channels.instance.broadcast(identifier, clear: clear)
     end
 
     def broadcast_to(model, clear = true)
-      CableReady::Channels.instance.broadcast_to(model, identifier, clear)
+      CableReady::Channels.instance.broadcast_to(model, identifier, clear: clear)
     end
 
     private


### PR DESCRIPTION
The current calling signature didn't match. This fixes that problem.