### PR TITLE
Add support for sessionStorage and localStorage

### DIFF
--- a/javascript/cable_ready.js
+++ b/javascript/cable_ready.js
@@ -119,6 +119,24 @@ const DOMOperations = {
     dispatch(document, 'cable-ready:after-push-state', config)
   },
 
+  // Storage .................................................................................................
+
+  storageSetItem: config => {
+    const { key, value, storageType } = config
+    dispatch(document, 'cable-ready:before-storage-set-item', config)
+    storage = storageType === 'session' ? sessionStorage : localStorage
+    storage.setItem(key, value)
+    dispatch(document, 'cable-ready:after-storage-set-item', config)
+  },
+
+  storageRemoveItem: config => {
+    const { key, storageType } = config
+    dispatch(document, 'cable-ready:before-storage-remove-item', config)
+    storage = storageType === 'session' ? sessionStorage : localStorage
+    storage.removeItem(key)
+    dispatch(document, 'cable-ready:after-storage-remove-item', config)
+  },
+
   // Notifications ...........................................................................................
 
   consoleLog: config => {

--- a/javascript/cable_ready.js
+++ b/javascript/cable_ready.js
@@ -124,7 +124,7 @@ const DOMOperations = {
   storageSetItem: config => {
     const { key, value, storageType } = config
     dispatch(document, 'cable-ready:before-storage-set-item', config)
-    storage = storageType === 'session' ? sessionStorage : localStorage
+    storage = type === 'session' ? sessionStorage : localStorage
     storage.setItem(key, value)
     dispatch(document, 'cable-ready:after-storage-set-item', config)
   },
@@ -132,7 +132,7 @@ const DOMOperations = {
   storageRemoveItem: config => {
     const { key, storageType } = config
     dispatch(document, 'cable-ready:before-storage-remove-item', config)
-    storage = storageType === 'session' ? sessionStorage : localStorage
+    storage = type === 'session' ? sessionStorage : localStorage
     storage.removeItem(key)
     dispatch(document, 'cable-ready:after-storage-remove-item', config)
   },

--- a/javascript/cable_ready.js
+++ b/javascript/cable_ready.js
@@ -122,7 +122,7 @@ const DOMOperations = {
   // Storage .................................................................................................
 
   storageSetItem: config => {
-    const { key, value, storageType } = config
+    const { key, value, type } = config
     dispatch(document, 'cable-ready:before-storage-set-item', config)
     storage = type === 'session' ? sessionStorage : localStorage
     storage.setItem(key, value)
@@ -130,7 +130,7 @@ const DOMOperations = {
   },
 
   storageRemoveItem: config => {
-    const { key, storageType } = config
+    const { key, type } = config
     dispatch(document, 'cable-ready:before-storage-remove-item', config)
     storage = type === 'session' ? sessionStorage : localStorage
     storage.removeItem(key)

--- a/lib/cable_ready/channels.rb
+++ b/lib/cable_ready/channels.rb
@@ -36,6 +36,8 @@ module CableReady
         set_style
         set_styles
         set_value
+        storage_remove_item
+        storage_set_item
         text_content
       ].each do |operation|
         add_operation operation


### PR DESCRIPTION
# Add support for sessionStorage and localStorage

## Example Usage

```ruby
cable_ready[stream_name]
  .storage_set_item(key: "local-example", value: "a value in local storage")
  .storage_set_item(key: "session-example", value: "a value in session storage", type: "session")
  .broadcast

cable_ready[stream_name]
  .storage_remove_item(key: "local-example")
  .storage_remove_item(key: "session-example", type: "session")
  .broadcast
```