### PR TITLE
Add more detail to the CableReady error message

### DIFF
--- a/javascript/cable_ready.js
+++ b/javascript/cable_ready.js
@@ -365,7 +365,7 @@ const perform = (
         } catch (e) {
           if (detail.element) {
             console.error(
-              `CableReady detected an error in ${name}! ${e.message}. If you need to support older browsers make sure you've included the corresponding polyfills. Check this out for more details: https://docs.stimulusreflex.com/setup#polyfills-for-ie11.`
+              `CableReady detected an error in ${name}! ${e.message}. If you need to support older browsers make sure you've included the corresponding polyfills. https://docs.stimulusreflex.com/setup#polyfills-for-ie11.`
             )
             console.error(e)
           } else {

--- a/javascript/cable_ready.js
+++ b/javascript/cable_ready.js
@@ -363,12 +363,14 @@ const perform = (
           if (detail.element || options.emitMissingElementWarnings)
             DOMOperations[name](detail)
         } catch (e) {
-          if (detail.element)
-            console.log(`CableReady detected an error in ${name}! ${e.message}`)
-          else
+          if (detail.element) {
+            console.error(`CableReady detected an error in ${name}! ${e.message}`)
+            console.error(e)
+          } else {
             console.log(
               `CableReady ${name} failed due to missing DOM element for selector: '${detail.selector}'`
             )
+          }
         }
       }
     }

--- a/javascript/cable_ready.js
+++ b/javascript/cable_ready.js
@@ -364,7 +364,9 @@ const perform = (
             DOMOperations[name](detail)
         } catch (e) {
           if (detail.element) {
-            console.error(`CableReady detected an error in ${name}! ${e.message}`)
+            console.error(
+              `CableReady detected an error in ${name}! ${e.message}`
+            )
             console.error(e)
           } else {
             console.log(

--- a/javascript/cable_ready.js
+++ b/javascript/cable_ready.js
@@ -365,7 +365,7 @@ const perform = (
         } catch (e) {
           if (detail.element) {
             console.error(
-              `CableReady detected an error in ${name}! ${e.message}`
+              `CableReady detected an error in ${name}! ${e.message}. If you need to support older browsers make sure you've included the corresponding polyfills. Check this out for more details: https://docs.stimulusreflex.com/setup#polyfills-for-ie11.`
             )
             console.error(e)
           } else {


### PR DESCRIPTION
# Type of PR
Enhancement

## Description

Currently it just states `CableReady detected an error in morph! Object doesn't support this action` which makes it pretty hard to debug.

#### Before

<img width="70%" alt="Screenshot 2020-12-12 at 17 56 11" src="https://user-images.githubusercontent.com/6411752/101990335-b3942400-3ca6-11eb-9f7d-9e2a4b4b7108.png">

#### After
Now it's shown as an error (which it obviously is), shows the source where the error was thrown and prints the error separately so you can have a look the the error/stack-trace. 

<img width="70%" alt="Screenshot 2020-12-12 at 19 31 36" src="https://user-images.githubusercontent.com/6411752/101992028-b3008b00-3cb0-11eb-899a-a4862e06330d.png">

## Why should this be added

Makes it easier to debug and DX.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update