### PR TITLE
changed storage method names, added clear flag

### DIFF
--- a/javascript/cable_ready.js
+++ b/javascript/cable_ready.js
@@ -121,20 +121,20 @@ const DOMOperations = {
 
   // Storage .................................................................................................
 
-  storageSetItem: config => {
+  setStorage: config => {
     const { key, value, type } = config
-    dispatch(document, 'cable-ready:before-storage-set-item', config)
+    dispatch(document, 'cable-ready:before-set-storage', config)
     const storage = type === 'session' ? sessionStorage : localStorage
     storage.setItem(key, value)
-    dispatch(document, 'cable-ready:after-storage-set-item', config)
+    dispatch(document, 'cable-ready:after-set-storage', config)
   },
 
-  storageRemoveItem: config => {
-    const { key, type } = config
-    dispatch(document, 'cable-ready:before-storage-remove-item', config)
+  removeStorage: config => {
+    const { key, type, clear } = config
+    dispatch(document, 'cable-ready:before-remove-storage', config)
     const storage = type === 'session' ? sessionStorage : localStorage
-    storage.removeItem(key)
-    dispatch(document, 'cable-ready:after-storage-remove-item', config)
+    clear ? storage.clear() : storage.removeItem(key)
+    dispatch(document, 'cable-ready:after-remove-storage', config)
   },
 
   // Notifications ...........................................................................................

--- a/lib/cable_ready/channels.rb
+++ b/lib/cable_ready/channels.rb
@@ -16,6 +16,7 @@ module CableReady
       @operations = {}
       %i[
         add_css_class
+        clear_storage
         console_log
         dispatch_event
         inner_html

--- a/lib/cable_ready/channels.rb
+++ b/lib/cable_ready/channels.rb
@@ -28,13 +28,13 @@ module CableReady
         remove
         remove_attribute
         remove_css_class
-        remove_storage
+        remove_storage_item
         set_attribute
         set_cookie
         set_dataset_property
         set_focus
         set_property
-        set_storage
+        set_storage_item
         set_style
         set_styles
         set_value

--- a/lib/cable_ready/channels.rb
+++ b/lib/cable_ready/channels.rb
@@ -28,16 +28,16 @@ module CableReady
         remove
         remove_attribute
         remove_css_class
+        remove_storage
         set_attribute
         set_cookie
         set_dataset_property
         set_focus
         set_property
+        set_storage
         set_style
         set_styles
         set_value
-        storage_remove_item
-        storage_set_item
         text_content
       ].each do |operation|
         add_operation operation


### PR DESCRIPTION
`set_storage` and `remove_storage` follow the naming convention used by every other operation.

I added a new optional `clear` flag to the `remove_storage` method that optionally clears all keys.