### PR TITLE
rework custom operations

### DIFF
--- a/lib/cable_ready/channels.rb
+++ b/lib/cable_ready/channels.rb
@@ -47,9 +47,9 @@ module CableReady
 
     def add_operation(operation)
       @operations[operation] = ->(options = {}) do
-          yield(options) if block_given?
-          enqueue_operation(operation, options)
-        end
+        yield(options) if block_given?
+        enqueue_operation(operation, options)
+      end
     end
 
     def [](identifier)

--- a/lib/cable_ready/channels.rb
+++ b/lib/cable_ready/channels.rb
@@ -45,8 +45,11 @@ module CableReady
       end
     end
 
-    def add_operation(operation, &implementation)
-      @operations[operation] = implementation || ->(options = {}) { enqueue_operation(operation, options) }
+    def add_operation(operation)
+      @operations[operation] = ->(options = {}) do
+          yield(options) if block_given?
+          enqueue_operation(operation, options)
+        end
     end
 
     def [](identifier)


### PR DESCRIPTION
I suspect that this effectively undocumented feature (made real in #47) hasn't been working as intended for some time. I believe you can currently add operations with default behaviour. Unfortunately, custom behaviour just falls down in today's CableReady, especially where method chaining is concerned.

On the eve of real documentation emerging, I suspect people will want to make use of this feature, and this PR fixes it.

```rb
CableReady::Channels.configure do |config|
  config.add_operation :jazz_hands do |options|
    puts options.inspect
    puts "Jazz hands!"
    puts rand 1..1000
  end
end
```

Now, I'm immediately putting this into draft because in truth... this might be a solution looking for a problem.

If this PR were accepted, the behaviour would be that the code in the block would execute when the operation was added to the queue. In my original (incorrect) conception, the code would fire at the time of the broadcast. This is incorrect.

So, the question becomes: which of these behaviours make the most sense?

1. I have a use case in mind where the current behaviour (block yield at the time I add an operation to the queue) makes sense.
2. I have a use case in mind, but I would prefer the block yield happen at the time of broadcast.
3. Let's pull out this block yield stuff and just add the custom operation to the list of available operations.

Basically, I think the idea of defining functionality for server-side behaviour as part of operations is cool, but I am hard pressed to come up with an example of how this could be used.