### PR TITLE
multiple selector element operations

### DIFF
--- a/javascript/cable_ready.js
+++ b/javascript/cable_ready.js
@@ -41,8 +41,10 @@ const DOMOperations = {
     processElements(operation, element => {
       dispatch(element, 'cable-ready:before-inner-html', operation)
       const { html, focusSelector } = operation
-      if (!operation.cancel) element.innerHTML = html
-      assignFocus(focusSelector)
+      if (!operation.cancel) {
+        element.innerHTML = html
+        assignFocus(focusSelector)
+      }
       dispatch(element, 'cable-ready:after-inner-html', operation)
     })
   },
@@ -51,9 +53,10 @@ const DOMOperations = {
     processElements(operation, element => {
       dispatch(element, 'cable-ready:before-insert-adjacent-html', operation)
       const { html, position, focusSelector } = operation
-      if (!operation.cancel)
+      if (!operation.cancel) {
         element.insertAdjacentHTML(position || 'beforeend', html)
-      assignFocus(focusSelector)
+        assignFocus(focusSelector)
+      }
       dispatch(element, 'cable-ready:after-insert-adjacent-html', operation)
     })
   },
@@ -62,9 +65,10 @@ const DOMOperations = {
     processElements(operation, element => {
       dispatch(element, 'cable-ready:before-insert-adjacent-text', operation)
       const { text, position, focusSelector } = operation
-      if (!operation.cancel)
+      if (!operation.cancel) {
         element.insertAdjacentText(position || 'beforeend', text)
-      assignFocus(focusSelector)
+        assignFocus(focusSelector)
+      }
       dispatch(element, 'cable-ready:after-insert-adjacent-text', operation)
     })
   },
@@ -80,7 +84,7 @@ const DOMOperations = {
       })
       const parent = element.parentElement
       const ordinal = Array.from(parent.children).indexOf(element)
-      if (!operation.cancel)
+      if (!operation.cancel) {
         morphdom(
           element,
           childrenOnly ? template.content : template.innerHTML,
@@ -90,7 +94,8 @@ const DOMOperations = {
             onElUpdated: didMorph(operation)
           }
         )
-      assignFocus(focusSelector)
+        assignFocus(focusSelector)
+      }
       dispatch(parent.children[ordinal], 'cable-ready:after-morph', {
         ...operation,
         content: template.content
@@ -104,8 +109,10 @@ const DOMOperations = {
       const { html, focusSelector } = operation
       const parent = element.parentElement
       const ordinal = Array.from(parent.children).indexOf(element)
-      if (!operation.cancel) element.outerHTML = html
-      assignFocus(focusSelector)
+      if (!operation.cancel) {
+        element.outerHTML = html
+        assignFocus(focusSelector)
+      }
       dispatch(
         parent.children[ordinal],
         'cable-ready:after-outer-html',
@@ -118,8 +125,10 @@ const DOMOperations = {
     processElements(operation, element => {
       dispatch(element, 'cable-ready:before-remove', operation)
       const { focusSelector } = operation
-      if (!operation.cancel) element.remove()
-      assignFocus(focusSelector)
+      if (!operation.cancel) {
+        element.remove()
+        assignFocus(focusSelector)
+      }
       dispatch(document, 'cable-ready:after-remove', operation)
     })
   },
@@ -128,8 +137,10 @@ const DOMOperations = {
     processElements(operation, element => {
       dispatch(element, 'cable-ready:before-text-content', operation)
       const { text, focusSelector } = operation
-      if (!operation.cancel) element.textContent = text
-      assignFocus(focusSelector)
+      if (!operation.cancel) {
+        element.textContent = text
+        assignFocus(focusSelector)
+      }
       dispatch(element, 'cable-ready:after-text-content', operation)
     })
   },
@@ -293,11 +304,11 @@ const DOMOperations = {
       Notification.requestPermission().then(result => {
         permission = result
         if (result === 'granted') new Notification(title || '', options)
-        dispatch(document, 'cable-ready:after-notification', {
-          ...operation,
-          permission
-        })
       })
+    dispatch(document, 'cable-ready:after-notification', {
+      ...operation,
+      permission
+    })
   }
 }
 

--- a/javascript/cable_ready.js
+++ b/javascript/cable_ready.js
@@ -1,6 +1,12 @@
 import morphdom from 'morphdom'
 import { verifyNotMutable, verifyNotPermanent } from './callbacks'
-import { assignFocus, dispatch, xpathToElement, getClassNames } from './utils'
+import {
+  assignFocus,
+  dispatch,
+  xpathToElement,
+  getClassNames,
+  processElements
+} from './utils'
 
 export let activeElement
 
@@ -10,11 +16,11 @@ const didMorphCallbacks = []
 // Indicates whether or not we should morph an element via onBeforeElUpdated callback
 // SEE: https://github.com/patrick-steele-idem/morphdom#morphdomfromnode-tonode-options--node
 //
-const shouldMorph = detail => (fromEl, toEl) => {
+const shouldMorph = operation => (fromEl, toEl) => {
   return !shouldMorphCallbacks
     .map(callback => {
       return typeof callback === 'function'
-        ? callback(detail, fromEl, toEl)
+        ? callback(operation, fromEl, toEl)
         : true
     })
     .includes(false)
@@ -22,251 +28,270 @@ const shouldMorph = detail => (fromEl, toEl) => {
 
 // Execute any pluggable functions that modify elements after morphing via onElUpdated callback
 //
-const didMorph = detail => el => {
+const didMorph = operation => el => {
   didMorphCallbacks.forEach(callback => {
-    if (typeof callback === 'function') callback(detail, el)
+    if (typeof callback === 'function') callback(operation, el)
   })
 }
 
-// Morphdom Callbacks ........................................................................................
-
 const DOMOperations = {
-  // Navigation ..............................................................................................
+  // DOM Mutations
 
-  pushState: config => {
-    const { state, title, url } = config
-    dispatch(document, 'cable-ready:before-push-state', config)
-    history.pushState(state || {}, title || '', url)
-    dispatch(document, 'cable-ready:after-push-state', config)
+  innerHtml: operation => {
+    processElements(operation, element => {
+      dispatch(element, 'cable-ready:before-inner-html', operation)
+      const { html, focusSelector } = operation
+      if (!operation.cancel) element.innerHTML = html
+      assignFocus(focusSelector)
+      dispatch(element, 'cable-ready:after-inner-html', operation)
+    })
   },
 
-  // Storage .................................................................................................
-
-  setStorageItem: config => {
-    const { key, value, type } = config
-    const storage = type === 'session' ? sessionStorage : localStorage
-    dispatch(document, 'cable-ready:before-set-storage-item', config)
-    storage.setItem(key, value)
-    dispatch(document, 'cable-ready:after-set-storage-item', config)
+  insertAdjacentHtml: operation => {
+    processElements(operation, element => {
+      dispatch(element, 'cable-ready:before-insert-adjacent-html', operation)
+      const { html, position, focusSelector } = operation
+      if (!operation.cancel)
+        element.insertAdjacentHTML(position || 'beforeend', html)
+      assignFocus(focusSelector)
+      dispatch(element, 'cable-ready:after-insert-adjacent-html', operation)
+    })
   },
 
-  removeStorageItem: config => {
-    const { key, type } = config
-    const storage = type === 'session' ? sessionStorage : localStorage
-    dispatch(document, 'cable-ready:before-remove-storage-item', config)
-    storage.removeItem(key)
-    dispatch(document, 'cable-ready:after-remove-storage-item', config)
+  insertAdjacentText: operation => {
+    processElements(operation, element => {
+      dispatch(element, 'cable-ready:before-insert-adjacent-text', operation)
+      const { text, position, focusSelector } = operation
+      if (!operation.cancel)
+        element.insertAdjacentText(position || 'beforeend', text)
+      assignFocus(focusSelector)
+      dispatch(element, 'cable-ready:after-insert-adjacent-text', operation)
+    })
   },
 
-  clearStorage: config => {
-    const { type } = config
+  morph: operation => {
+    processElements(operation, element => {
+      const { html, childrenOnly, focusSelector } = operation
+      const template = document.createElement('template')
+      template.innerHTML = String(html).trim()
+      dispatch(element, 'cable-ready:before-morph', {
+        ...operation,
+        content: template.content
+      })
+      const parent = element.parentElement
+      const ordinal = Array.from(parent.children).indexOf(element)
+      morphdom(element, childrenOnly ? template.content : template.innerHTML, {
+        childrenOnly: !!childrenOnly,
+        onBeforeElUpdated: shouldMorph(operation),
+        onElUpdated: didMorph(operation)
+      })
+      assignFocus(focusSelector)
+      dispatch(parent.children[ordinal], 'cable-ready:after-morph', {
+        ...operation,
+        content: template.content
+      })
+    })
+  },
+
+  outerHtml: operation => {
+    processElements(operation, element => {
+      dispatch(element, 'cable-ready:before-outer-html', operation)
+      const { html, focusSelector } = operation
+      const parent = element.parentElement
+      const ordinal = Array.from(parent.children).indexOf(element)
+      if (!operation.cancel) element.outerHTML = html
+      assignFocus(focusSelector)
+      dispatch(
+        parent.children[ordinal],
+        'cable-ready:after-outer-html',
+        operation
+      )
+    })
+  },
+
+  remove: operation => {
+    processElements(operation, element => {
+      dispatch(element, 'cable-ready:before-remove', operation)
+      const { focusSelector } = operation
+      if (!operation.cancel) element.remove()
+      assignFocus(focusSelector)
+      dispatch(element, 'cable-ready:after-remove', operation)
+    })
+  },
+
+  textContent: operation => {
+    processElements(operation, element => {
+      dispatch(element, 'cable-ready:before-text-content', operation)
+      const { text, focusSelector } = operation
+      if (!operation.cancel) element.textContent = text
+      assignFocus(focusSelector)
+      dispatch(element, 'cable-ready:after-text-content', operation)
+    })
+  },
+
+  // Element Mutations
+
+  addCssClass: operation => {
+    processElements(operation, element => {
+      dispatch(element, 'cable-ready:before-add-css-class', operation)
+      const { name } = operation
+      if (!operation.cancel) element.classList.add(...getClassNames(name))
+      dispatch(element, 'cable-ready:after-add-css-class', operation)
+    })
+  },
+
+  removeAttribute: operation => {
+    processElements(operation, element => {
+      dispatch(element, 'cable-ready:before-remove-attribute', operation)
+      const { name } = operation
+      if (!operation.cancel) element.removeAttribute(name)
+      dispatch(element, 'cable-ready:after-remove-attribute', operation)
+    })
+  },
+
+  removeCssClass: operation => {
+    processElements(operation, element => {
+      dispatch(element, 'cable-ready:before-remove-css-class', operation)
+      const { name } = operation
+      if (!operation.cancel) element.classList.remove(...getClassNames(name))
+      dispatch(element, 'cable-ready:after-remove-css-class', operation)
+    })
+  },
+
+  setAttribute: operation => {
+    processElements(operation, element => {
+      dispatch(element, 'cable-ready:before-set-attribute', operation)
+      const { name, value } = operation
+      if (!operation.cancel) element.setAttribute(name, value)
+      dispatch(element, 'cable-ready:after-set-attribute', operation)
+    })
+  },
+
+  setDatasetProperty: operation => {
+    processElements(operation, element => {
+      dispatch(element, 'cable-ready:before-set-dataset-property', operation)
+      const { name, value } = operation
+      if (!operation.cancel) element.dataset[name] = value
+      dispatch(element, 'cable-ready:after-set-dataset-property', operation)
+    })
+  },
+
+  setProperty: operation => {
+    processElements(operation, element => {
+      dispatch(element, 'cable-ready:before-set-property', operation)
+      const { name, value } = operation
+      if (!operation.cancel && name in element) element[name] = value
+      dispatch(element, 'cable-ready:after-set-property', operation)
+    })
+  },
+
+  setStyle: operation => {
+    processElements(operation, element => {
+      dispatch(element, 'cable-ready:before-set-style', operation)
+      const { name, value } = operation
+      if (!operation.cancel) element.style[name] = value
+      dispatch(element, 'cable-ready:after-set-style', operation)
+    })
+  },
+
+  setStyles: operation => {
+    processElements(operation, element => {
+      dispatch(element, 'cable-ready:before-set-styles', operation)
+      const { styles } = operation
+      for (let [name, value] of Object.entries(styles)) {
+        if (!operation.cancel) element.style[name] = value
+      }
+      dispatch(element, 'cable-ready:after-set-styles', operation)
+    })
+  },
+
+  setValue: operation => {
+    processElements(operation, element => {
+      dispatch(element, 'cable-ready:before-set-value', operation)
+      const { value } = operation
+      if (!operation.cancel) element.value = value
+      dispatch(element, 'cable-ready:after-set-value', operation)
+    })
+  },
+
+  // DOM Events
+
+  dispatchEvent: operation => {
+    processElements(operation, element => {
+      const { name, detail } = operation
+      dispatch(element, name, detail)
+    })
+  },
+
+  // Browser Manipulations
+
+  clearStorage: operation => {
+    const { type } = operation
     const storage = type === 'session' ? sessionStorage : localStorage
-    dispatch(document, 'cable-ready:before-clear-storage', config)
+    dispatch(document, 'cable-ready:before-clear-storage', operation)
     storage.clear()
-    dispatch(document, 'cable-ready:after-clear-storage', config)
+    dispatch(document, 'cable-ready:after-clear-storage', operation)
   },
 
-  // Notifications ...........................................................................................
+  pushState: operation => {
+    const { state, title, url } = operation
+    dispatch(document, 'cable-ready:before-push-state', operation)
+    history.pushState(state || {}, title || '', url)
+    dispatch(document, 'cable-ready:after-push-state', operation)
+  },
 
-  consoleLog: config => {
-    const { message, level } = config
+  removeStorageItem: operation => {
+    const { key, type } = operation
+    const storage = type === 'session' ? sessionStorage : localStorage
+    dispatch(document, 'cable-ready:before-remove-storage-item', operation)
+    storage.removeItem(key)
+    dispatch(document, 'cable-ready:after-remove-storage-item', operation)
+  },
+
+  setCookie: operation => {
+    const { cookie } = operation
+    dispatch(document, 'cable-ready:before-set-cookie', operation)
+    document.cookie = cookie
+    dispatch(document, 'cable-ready:after-set-cookie', operation)
+  },
+
+  setFocus: operation => {
+    processElements(operation, element => {
+      dispatch(element, 'cable-ready:before-set-focus', operation)
+      assignFocus(element)
+      dispatch(element, 'cable-ready:after-set-focus', operation)
+    })
+  },
+
+  setStorageItem: operation => {
+    const { key, value, type } = operation
+    const storage = type === 'session' ? sessionStorage : localStorage
+    dispatch(document, 'cable-ready:before-set-storage-item', operation)
+    storage.setItem(key, value)
+    dispatch(document, 'cable-ready:after-set-storage-item', operation)
+  },
+
+  // Notifications
+
+  consoleLog: operation => {
+    const { message, level } = operation
     level && ['warn', 'info', 'error'].includes(level)
       ? console[level](message)
       : console.log(message)
   },
 
-  notification: config => {
-    const { title, options } = config
-    dispatch(document, 'cable-ready:before-notification', config)
+  notification: operation => {
+    const { title, options } = operation
+    dispatch(document, 'cable-ready:before-notification', operation)
     let permission
     Notification.requestPermission().then(result => {
       permission = result
       if (result === 'granted') new Notification(title || '', options)
       dispatch(document, 'cable-ready:after-notification', {
-        ...config,
+        ...operation,
         permission
       })
     })
-  },
-
-  // Cookies .................................................................................................
-
-  setCookie: config => {
-    const { cookie } = config
-    dispatch(document, 'cable-ready:before-set-cookie', config)
-    document.cookie = cookie
-    dispatch(document, 'cable-ready:after-set-cookie', config)
-  },
-
-  // DOM Events ..............................................................................................
-
-  dispatchEvent: config => {
-    const { element, name, detail } = config
-    dispatch(element, name, detail)
-  },
-
-  // Element Mutations .......................................................................................
-
-  morph: detail => {
-    activeElement = document.activeElement
-    const { element, html, childrenOnly, focusSelector } = detail
-    const template = document.createElement('template')
-    template.innerHTML = String(html).trim()
-    dispatch(element, 'cable-ready:before-morph', {
-      ...detail,
-      content: template.content
-    })
-    const parent = element.parentElement
-    const ordinal = Array.from(parent.children).indexOf(element)
-    morphdom(element, childrenOnly ? template.content : template.innerHTML, {
-      childrenOnly: !!childrenOnly,
-      onBeforeElUpdated: shouldMorph(detail),
-      onElUpdated: didMorph(detail)
-    })
-    assignFocus(focusSelector)
-    dispatch(parent.children[ordinal], 'cable-ready:after-morph', {
-      ...detail,
-      content: template.content
-    })
-  },
-
-  innerHtml: detail => {
-    activeElement = document.activeElement
-    const { element, html, focusSelector } = detail
-    dispatch(element, 'cable-ready:before-inner-html', detail)
-    element.innerHTML = html
-    assignFocus(focusSelector)
-    dispatch(element, 'cable-ready:after-inner-html', detail)
-  },
-
-  outerHtml: detail => {
-    activeElement = document.activeElement
-    const { element, html, focusSelector } = detail
-    dispatch(element, 'cable-ready:before-outer-html', detail)
-    const parent = element.parentElement
-    const ordinal = Array.from(parent.children).indexOf(element)
-    element.outerHTML = html
-    assignFocus(focusSelector)
-    dispatch(parent.children[ordinal], 'cable-ready:after-outer-html', detail)
-  },
-
-  textContent: detail => {
-    activeElement = document.activeElement
-    const { element, text, focusSelector } = detail
-    dispatch(element, 'cable-ready:before-text-content', detail)
-    element.textContent = text
-    assignFocus(focusSelector)
-    dispatch(element, 'cable-ready:after-text-content', detail)
-  },
-
-  insertAdjacentHtml: detail => {
-    activeElement = document.activeElement
-    const { element, html, position, focusSelector } = detail
-    dispatch(element, 'cable-ready:before-insert-adjacent-html', detail)
-    element.insertAdjacentHTML(position || 'beforeend', html)
-    assignFocus(focusSelector)
-    dispatch(element, 'cable-ready:after-insert-adjacent-html', detail)
-  },
-
-  insertAdjacentText: detail => {
-    activeElement = document.activeElement
-    const { element, text, position, focusSelector } = detail
-    dispatch(element, 'cable-ready:before-insert-adjacent-text', detail)
-    element.insertAdjacentText(position || 'beforeend', text)
-    assignFocus(focusSelector)
-    dispatch(element, 'cable-ready:after-insert-adjacent-text', detail)
-  },
-
-  remove: detail => {
-    activeElement = document.activeElement
-    const { element, focusSelector } = detail
-    dispatch(element, 'cable-ready:before-remove', detail)
-    element.remove()
-    assignFocus(focusSelector)
-    dispatch(element, 'cable-ready:after-remove', detail)
-  },
-
-  setFocus: detail => {
-    activeElement = document.activeElement
-    const { element } = detail
-    dispatch(element, 'cable-ready:before-set-focus', detail)
-    assignFocus(element)
-    dispatch(element, 'cable-ready:after-set-focus', detail)
-  },
-
-  setProperty: detail => {
-    const { element, name, value } = detail
-    dispatch(element, 'cable-ready:before-set-property', detail)
-    if (name in element) element[name] = value
-    dispatch(element, 'cable-ready:after-set-property', detail)
-  },
-
-  setValue: detail => {
-    activeElement = document.activeElement
-    const { element, value, focusSelector } = detail
-    dispatch(element, 'cable-ready:before-set-value', detail)
-    element.value = value
-    assignFocus(focusSelector)
-    dispatch(element, 'cable-ready:after-set-value', detail)
-  },
-
-  // Attribute Mutations .....................................................................................
-
-  setAttribute: detail => {
-    const { element, name, value } = detail
-    dispatch(element, 'cable-ready:before-set-attribute', detail)
-    element.setAttribute(name, value)
-    dispatch(element, 'cable-ready:after-set-attribute', detail)
-  },
-
-  removeAttribute: detail => {
-    const { element, name } = detail
-    dispatch(element, 'cable-ready:before-remove-attribute', detail)
-    element.removeAttribute(name)
-    dispatch(element, 'cable-ready:after-remove-attribute', detail)
-  },
-
-  // CSS Class Mutations .....................................................................................
-
-  addCssClass: detail => {
-    const { element, name } = detail
-    dispatch(element, 'cable-ready:before-add-css-class', detail)
-    element.classList.add(...getClassNames(name))
-    dispatch(element, 'cable-ready:after-add-css-class', detail)
-  },
-
-  removeCssClass: detail => {
-    const { element, name } = detail
-    dispatch(element, 'cable-ready:before-remove-css-class', detail)
-    element.classList.remove(...getClassNames(name))
-    dispatch(element, 'cable-ready:after-remove-css-class', detail)
-  },
-
-  // Style Mutations .......................................................................................
-
-  setStyle: detail => {
-    const { element, name, value } = detail
-    dispatch(element, 'cable-ready:before-set-style', detail)
-    element.style[name] = value
-    dispatch(element, 'cable-ready:after-set-style', detail)
-  },
-
-  setStyles: detail => {
-    const { element, styles } = detail
-    dispatch(element, 'cable-ready:before-set-styles', detail)
-    for (let [name, value] of Object.entries(styles)) {
-      element.style[name] = value
-    }
-    dispatch(element, 'cable-ready:after-set-styles', detail)
-  },
-
-  // Dataset Mutations .......................................................................................
-
-  setDatasetProperty: detail => {
-    const { element, name, value } = detail
-    dispatch(element, 'cable-ready:before-set-dataset-property', detail)
-    element.dataset[name] = value
-    dispatch(element, 'cable-ready:after-set-dataset-property', detail)
   }
 }
 
@@ -278,26 +303,28 @@ const perform = (
     if (operations.hasOwnProperty(name)) {
       const entries = operations[name]
       for (let i = 0; i < entries.length; i++) {
-        const detail = entries[i]
+        const operation = entries[i]
         try {
-          if (detail.selector) {
-            detail.element = detail.xpath
-              ? xpathToElement(detail.selector)
-              : document.querySelector(detail.selector)
+          if (operation.selector) {
+            operation.element = operation.xpath
+              ? [xpathToElement(operation.selector)]
+              : document.querySelectorAll(operation.selector)
           } else {
-            detail.element = document
+            operation.element = [document]
           }
-          if (detail.element || options.emitMissingElementWarnings)
-            DOMOperations[name](detail)
+          if (operation.element || options.emitMissingElementWarnings) {
+            activeElement = document.activeElement
+            DOMOperations[name](operation)
+          }
         } catch (e) {
-          if (detail.element) {
+          if (operation.element) {
             console.error(
               `CableReady detected an error in ${name}! ${e.message}. If you need to support older browsers make sure you've included the corresponding polyfills. https://docs.stimulusreflex.com/setup#polyfills-for-ie11.`
             )
             console.error(e)
           } else {
             console.log(
-              `CableReady ${name} failed due to missing DOM element for selector: '${detail.selector}'`
+              `CableReady ${name} failed due to missing DOM element for selector: '${operation.selector}'`
             )
           }
         }

--- a/javascript/cable_ready.js
+++ b/javascript/cable_ready.js
@@ -307,10 +307,12 @@ const perform = (
         try {
           if (operation.selector) {
             operation.element = operation.xpath
-              ? [xpathToElement(operation.selector)]
-              : document.querySelectorAll(operation.selector)
+              ? xpathToElement(operation.selector)
+              : document[
+                  operation.selectAll ? 'querySelectorAll' : 'querySelector'
+                ](operation.selector)
           } else {
-            operation.element = [document]
+            operation.element = document
           }
           if (operation.element || options.emitMissingElementWarnings) {
             activeElement = document.activeElement

--- a/javascript/cable_ready.js
+++ b/javascript/cable_ready.js
@@ -78,10 +78,8 @@ const DOMOperations = {
       const { html, childrenOnly, focusSelector } = operation
       const template = document.createElement('template')
       template.innerHTML = String(html).trim()
-      dispatch(element, 'cable-ready:before-morph', {
-        ...operation,
-        content: template.content
-      })
+      operation.content = template.content
+      dispatch(element, 'cable-ready:before-morph', operation)
       const parent = element.parentElement
       const ordinal = Array.from(parent.children).indexOf(element)
       if (!operation.cancel) {
@@ -96,10 +94,7 @@ const DOMOperations = {
         )
         assignFocus(focusSelector)
       }
-      dispatch(parent.children[ordinal], 'cable-ready:after-morph', {
-        ...operation,
-        content: template.content
-      })
+      dispatch(parent.children[ordinal], 'cable-ready:after-morph', operation)
     })
   },
 

--- a/javascript/utils.js
+++ b/javascript/utils.js
@@ -50,3 +50,14 @@ export const xpathToElement = xpath => {
 // * names - could be a string or an array of strings for multiple classes.
 //
 export const getClassNames = names => Array(names).flat()
+
+// Perform operation for either the first or all of the elements returned by CSS selector
+//
+// * operation - the instruction payload from perform
+// * callback - the operation function to run for each element
+//
+export const processElements = (operation, callback) => {
+  Array.from(operation.element)
+    .slice(0, operation.selectAll ? operation.element.length : 1)
+    .forEach(callback)
+}

--- a/javascript/utils.js
+++ b/javascript/utils.js
@@ -57,7 +57,7 @@ export const getClassNames = names => Array(names).flat()
 // * callback - the operation function to run for each element
 //
 export const processElements = (operation, callback) => {
-  Array.from(operation.element)
-    .slice(0, operation.selectAll ? operation.element.length : 1)
-    .forEach(callback)
+  Array.from(
+    operation.selectAll ? operation.element : [operation.element]
+  ).forEach(callback)
 }


### PR DESCRIPTION
**With genuine apologies for borking** #90.

This PR proposes the following changes:

1. All `selector` parameters now accept CSS queries that can return multiple elements. ~~Internally, `element` is now handled as an array. This includes the default, `[document]` and values returned via XPath.~~ `event.detail.element` is not an array unless `selectAll` is passed. Since nobody is currently using a feature that hasn't been released yet, this doesn't break SemVer.
2. There is a new `processList` utility function that handles calling operations either for the first element or all elements in the array, depending on whether the `selectAll: true` parameter has been passed. It defaults to just the first element, which should be the current behaviour.
3. I moved `activeElement = document.activeElement` to the `perform` function #DRY
4. I removed the `assignFocus`/`focusSelector` option from `set_value` since it's not supposed to be there and wasn't documented.
5. I moved the object destructuring to below the `before-operation` callback, giving the developers the opportunity to implement event handlers which change the parameters of the operation. For example, we had a user request to be able to change the `html` in a `before-inner-html` callback today. This is a power-user move, but it's a power-user library.
6. I added the ability to cancel operations during a `before-operation` callback by adding a `cancel: true` pair to the operation. This applies to all DOM mutation and element mutation operations **that are not morph**, which is just too complex to support cancel.
7. I consolidated all of the method parameters to be `operation` instead of `detail` or `config`. This should not impact the `detail` object produced by the `dispatch_event` operation.
8. Finally, I reordered all of the operations so that they are finally in a 1:1 order with how they are introduced in the docs, eg. by section and then alphabetical.

If anything in here doesn't pass muster, I'm happy to pull it out.

Now, I know that it's uncharacteristic of me but I would really like to implement some kind of test runner for the CableReady client. I want to be able to make these sorts of refactors without sweating that I'm going to break something dumb. I have tried a bunch of basic scenarios but it would be really great to have a long boring list of assertions to run after something like this.

~~Aside from the removal of the `assignFocus` call from `set_value` the only change that should bubble to the surface is I think harmless and minor; now that `element` is stored as an array, operations with selectors that match multiple elements will show up as an array of elements in the `detail` object of the event, even if `selectAll` is not set. I think that anyone looking for the current element is going to pull it from *event*.target, not *event*.detail.element. Right?~~