### PR TITLE
cable_car aka 'Ajax mode'

### DIFF
--- a/lib/cable_ready/broadcaster.rb
+++ b/lib/cable_ready/broadcaster.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "channels"
+require_relative "cable_car"
 
 module CableReady
   module Broadcaster
@@ -8,6 +9,10 @@ module CableReady
 
     def cable_ready
       CableReady::Channels.instance
+    end
+
+    def cable_car
+      CableReady::CableCar.instance
     end
 
     def dom_id(record, prefix = nil)

--- a/lib/cable_ready/cable_car.rb
+++ b/lib/cable_ready/cable_car.rb
@@ -16,10 +16,10 @@ module CableReady
       ObjectSpace.define_finalizer self, -> { CableReady.config.delete_observer config_observer }
     end
 
-    def to_json(clear: true)
-      json = {"cableReady" => true, "operations" => transmitable_operations}.to_json
+    def ride(clear: true)
+      payload = transmitable_operations
       reset if clear
-      json
+      payload
     end
 
     def add_operation_method(name)

--- a/lib/cable_ready/cable_car.rb
+++ b/lib/cable_ready/cable_car.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "thread/local"
+
+module CableReady
+  class CableCar
+    extend Thread::Local
+    attr_reader :enqueued_operations
+
+    def initialize
+      reset
+      CableReady.config.operation_names.each { |name| add_operation_method name }
+
+      config_observer = self
+      CableReady.config.add_observer config_observer, :add_operation_method
+      ObjectSpace.define_finalizer self, -> { CableReady.config.delete_observer config_observer }
+    end
+
+    def to_json(clear: true)
+      json = {"cableReady" => true, "operations" => transmitable_operations}.to_json
+      reset if clear
+      json
+    end
+
+    def add_operation_method(name)
+      return if respond_to?(name)
+      singleton_class.public_send :define_method, name, ->(options = {}) {
+        enqueued_operations[name.to_s] << options.stringify_keys
+        self # supports operation chaining
+      }
+    end
+
+    private
+
+    def reset
+      @enqueued_operations = Hash.new { |hash, key| hash[key] = [] }
+    end
+
+    def transmitable_operations
+      enqueued_operations
+        .select { |_, list| list.present? }
+        .deep_transform_keys! { |key| key.to_s.camelize(:lower) }
+    end
+  end
+end

--- a/lib/cable_ready/channels.rb
+++ b/lib/cable_ready/channels.rb
@@ -9,11 +9,8 @@ module CableReady
   class Channels
     extend Thread::Local
 
-    attr_accessor :operations
-
     def initialize
       @channels = {}
-      @operations = {}
     end
 
     def [](identifier)


### PR DESCRIPTION
People have started to notice that you can call `CableReady.perform` anywhere, including outside of an `ActionCable#received` callback. @jonsgreen calls it inside of a custom CR operation, transforming it into a DSL for DOM manipulation. All you need is a viable JSON payload and you're good to go.

As we prepare for a multi-transport future in SR, so too must CR adapt to non-ActionCable usage cases. This PR proposes `cable_car`: a simplified, transport-agnostic class used for generating CableReady-compliant JSON payloads.

`cable_car` has an almost identical usage pattern as string identifier channels inside Reflex classes, except that instead of `broadcast`, chains are terminated by `.ride`.

`cable_car` is a Singleton like `cable_ready`, and observes the same operations list from the `config` class. Calling `ride` clears out the enqueued operations unless you call it with `clear: false`. It should be completely fine to use `cable_ready` and `cable_car` alongside each other, perhaps simultaneously.

**I also removed what I believe were vestigal references to `@operations` from the `Channels` class.**

```rb
Rails.application.routes.draw do
  get "fetch", to: "home#fetch", constraints: lambda { |request| request.xhr? } 
end
```

```js
import { Controller } from 'stimulus'
import CableReady from 'cable_ready'

export default class extends Controller {
  fetch () {
    fetch('/fetch.json', {
      headers: { 'X-Requested-With': 'XMLHttpRequest' }
    })
      .then(response => response.json())
      .then(data => CableReady.perform(data))
  }
}
```

```html
<button data-controller="cable-car" data-action="cable-car#fetch">Cable Car</button>
<div id="users"></div>
```

```rb
class HomeController < ApplicationController
  include CableReady::Broadcaster

  def fetch
    render json: cable_car
      .inner_html(selector: "#users", html: "<span>winning</span>")
      .set_focus(selector: "#users")
      .play_sound(src: "song.mp3")
      .ride
  end
end
```
```json
# {"innerHtml":[{"selector":"#users","html":"\u003cspan\u003ewinning\u003c/span\u003e"}],"setFocus":[{"selector":"#users"}],"playSound":[{"src":"song.mp3"}]}
```

## To be discussed

- if not `ride`, then what? `emit`, `finalize`, `payload`? I tried to find a good action verb that was also on-theme
- I didn't see the need to keep the `cableReady: true` and `operations` because this is contextually different, but they can certainly come back if you miss them