### PR TITLE
sound opt-in

### DIFF
--- a/javascript/cable_ready.js
+++ b/javascript/cable_ready.js
@@ -60,7 +60,7 @@ const performAsync = (
 }
 
 document.addEventListener('DOMContentLoaded', function () {
-  if (!document.audio) {
+  if (!document.audio && document.body.hasAttribute('data-unlock-audio')) {
     document.audio = new Audio(
       'data:audio/mpeg;base64,//OExAAAAAAAAAAAAEluZm8AAAAHAAAABAAAASAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPz8/Pz8/Pz8/Pz8/Pz8/Pz8/Pz8/Pz8/P39/f39/f39/f39/f39/f39/f39/f39/f3+/v7+/v7+/v7+/v7+/v7+/v7+/v7+/v7+/AAAAAAAAAAAAAAAAAAAAAAAAAAAAJAa/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA//MUxAAAAANIAAAAAExBTUUzLjk2LjFV//MUxAsAAANIAAAAAFVVVVVVVVVVVVVV//MUxBYAAANIAAAAAFVVVVVVVVVVVVVV//MUxCEAAANIAAAAAFVVVVVVVVVVVVVV'
     )

--- a/javascript/operations.js
+++ b/javascript/operations.js
@@ -351,7 +351,7 @@ export default {
         document.audio.play()
       }
       const ended = () => {
-        document.audio.removeEventListener('ended', canplaythrough)
+        document.audio.removeEventListener('ended', ended)
         dispatch(document, 'cable-ready:after-play-sound', operation)
       }
       if (document.body.hasAttribute('data-unlock-audio')) {

--- a/javascript/operations.js
+++ b/javascript/operations.js
@@ -354,10 +354,12 @@ export default {
         document.audio.removeEventListener('ended', canplaythrough)
         dispatch(document, 'cable-ready:after-play-sound', operation)
       }
-      document.audio.addEventListener('canplaythrough', canplaythrough)
-      document.audio.addEventListener('ended', ended)
-      if (src) document.audio.src = src
-      document.audio.play()
+      if (document.body.hasAttribute('data-unlock-audio')) {
+        document.audio.addEventListener('canplaythrough', canplaythrough)
+        document.audio.addEventListener('ended', ended)
+        if (src) document.audio.src = src
+        document.audio.play()
+      } else dispatch(document, 'cable-ready:after-play-sound', operation)
     } else dispatch(document, 'cable-ready:after-play-sound', operation)
   }
 }


### PR DESCRIPTION
It seems as though I was over-zealous in my enthusiasm for the `play_sound` operation; the bootstrap code interferes with strict CSPs and hijacks the audio context on a Mac.

This PR introduces a requirement that developers who wish to use the `play_sound` operation must place a `data-unlock-audio` attribute on their `body` tag. Otherwise, the operation will be a NOOP.

Fixes #111 