### PR TITLE
set_meta operation

### DIFF
--- a/javascript/operations.js
+++ b/javascript/operations.js
@@ -258,7 +258,7 @@ export default {
     dispatch(document, 'cable-ready:before-set-meta', operation)
     const { name, content } = operation
     if (!operation.cancel) {
-      let meta = document.head.querySelector(`meta[name=${name}]`)
+      let meta = document.head.querySelector(`meta[name='${name}']`)
       if (!meta) {
         meta = document.createElement('meta')
         meta.name = name

--- a/javascript/operations.js
+++ b/javascript/operations.js
@@ -254,6 +254,21 @@ export default {
     })
   },
 
+  setMeta: operation => {
+    dispatch(document, 'cable-ready:before-set-meta', operation)
+    const { name, content } = operation
+    if (!operation.cancel) {
+      let meta = document.head.querySelector(`meta[name=${name}]`)
+      if (!meta) {
+        meta = document.createElement('meta')
+        meta.name = name
+        document.head.appendChild(meta)
+      }
+      meta.content = content
+    }
+    dispatch(document, 'cable-ready:after-set-meta', operation)
+  },
+
   // Browser Manipulations
 
   clearStorage: operation => {

--- a/lib/cable_ready/config.rb
+++ b/lib/cable_ready/config.rb
@@ -60,6 +60,7 @@ module CableReady
         set_cookie
         set_dataset_property
         set_focus
+        set_meta
         set_property
         set_storage_item
         set_style


### PR DESCRIPTION
# Description

`set_meta` updates the `content` of a `meta` tag in the document head.

If no tag is found, it is created.

# Example

Here's a Nothing Reflex that updates a meta tag:
```rb
  def meta
    cable_ready.set_meta(name: "pill-messages", content: "5").broadcast
    morph :nothing
  end
```

# Motivation

I've found a really interesting pattern for building UI functionality that makes extensive use of `meta` tags.

<img width="150" alt="chrome_JV9t4dGYnE" src="https://user-images.githubusercontent.com/38150464/113825673-458cd480-974f-11eb-9e70-28e3992a805e.png">

```html
<span class="badge badge-md bg-danger text-white" data-controller="pill" data-pill-tag-value="messages">4</span>
```

This is all tied together with a Stimulus controller that observes `meta` tags:
```js
import { Controller } from 'stimulus'

export default class extends Controller {
  static values = { tag: String }

  initialize () {
    this.metaTag = document.head.querySelector(
      `meta[name=pill-${this.tagValue}]`
    )
    this.element.textContent = this.metaTag.content
    this.observer = new MutationObserver(this.meta)
  }

  connect () {
    this.observer.observe(this.metaTag, {
      attributeFilter: ['content']
    })
  }

  disconnect () {
    this.observer.disconnect()
  }

  meta = mutation => {
    const content = mutation[0].target.content
    if (content && content !== '0') {
      this.element.textContent = mutation[0].target.content
      this.element.classList.remove('d-none')
    } else {
      this.element.textContent = ''
      this.element.classList.add('d-none')
    }
  }
}
```

Basically, any menu items which can feature a notification "pill" observe a `meta` tag for changes, and update themselves when the meta tag is updated. If there is no `content` or the content is `0`, the pill is hidden.

This is very similar to using `set_dataset_property` with the Values API, except that it has two advantages:
- multiple elements can pick up changes from the `meta` tag, and they don't have to be aware of each other
- this solution is decoupled from knowing the location of an element in the DOM to receive the dataset property update