### PR TITLE
Make sound opt-in backwards compatible

### DIFF
--- a/docs/reference/operations/notifications.md
+++ b/docs/reference/operations/notifications.md
@@ -100,6 +100,8 @@ cable_ready["MyChannel"].play_sound(
 
 {% hint style="info" %}
 CableReady creates an HTML Audio instance on `document.audio` when the page loads. This object is technically available for you to use in your application as you see fit. Check out MDN for the full [audio API](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio).
+
+If you want to disable this, add the `data-lock-audio` attribute to your `body` tag.
 {% endhint %}
 
 #### Life-cycle Callback Events

--- a/javascript/cable_ready.js
+++ b/javascript/cable_ready.js
@@ -60,7 +60,7 @@ const performAsync = (
 }
 
 document.addEventListener('DOMContentLoaded', function () {
-  if (!document.audio && document.body.hasAttribute('data-unlock-audio')) {
+  if (!document.audio && !document.body.hasAttribute('data-lock-audio')) {
     document.audio = new Audio(
       'data:audio/mpeg;base64,//OExAAAAAAAAAAAAEluZm8AAAAHAAAABAAAASAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPz8/Pz8/Pz8/Pz8/Pz8/Pz8/Pz8/Pz8/P39/f39/f39/f39/f39/f39/f39/f39/f3+/v7+/v7+/v7+/v7+/v7+/v7+/v7+/v7+/AAAAAAAAAAAAAAAAAAAAAAAAAAAAJAa/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA//MUxAAAAANIAAAAAExBTUUzLjk2LjFV//MUxAsAAANIAAAAAFVVVVVVVVVVVVVV//MUxBYAAANIAAAAAFVVVVVVVVVVVVVV//MUxCEAAANIAAAAAFVVVVVVVVVVVVVV'
     )

--- a/javascript/operations.js
+++ b/javascript/operations.js
@@ -369,7 +369,7 @@ export default {
         document.audio.removeEventListener('ended', ended)
         dispatch(document, 'cable-ready:after-play-sound', operation)
       }
-      if (document.body.hasAttribute('data-unlock-audio')) {
+      if (!document.body.hasAttribute('data-lock-audio')) {
         document.audio.addEventListener('canplaythrough', canplaythrough)
         document.audio.addEventListener('ended', ended)
         if (src) document.audio.src = src


### PR DESCRIPTION
Audio was made opt-in in #112 but this breaks the current default by
disabling audio. This commit changes it back to the current default (on)
but allows people to turn it off by adding the `data-lock-audio`
attribute.

I personally think that audio should be opt-in, but opening this in case you
don't want to introduce the breaking change.