### PR TITLE
broadcast_later

### DIFF
--- a/app/jobs/cable_ready_broadcast_job.rb
+++ b/app/jobs/cable_ready_broadcast_job.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CableReadyBroadcastJob < ActiveJob::Base
+  include CableReady::Broadcaster
+  queue_as :default
+
+  def perform(identifier:, operations:, model: nil)
+    if model.present?
+      cable_ready[identifier.safe_constantize].apply!(operations).broadcast_to(model)
+    else
+      cable_ready[identifier].apply!(operations).broadcast
+    end
+  end
+end

--- a/lib/cable_ready/channel.rb
+++ b/lib/cable_ready/channel.rb
@@ -13,5 +13,15 @@ module CableReady
       identifier.broadcast_to model, {"cableReady" => true, "operations" => operations_payload}
       reset! if clear
     end
+
+    def broadcast_later(clear: true)
+      CableReadyBroadcastJob.perform_later(identifier: identifier, operations: operations_payload)
+      reset! if clear
+    end
+
+    def broadcast_later_to(model, clear: true)
+      CableReadyBroadcastJob.perform_later(identifier: identifier.name, operations: operations_payload, model: model)
+      reset! if clear
+    end
   end
 end


### PR DESCRIPTION
This PR enables to delegate broadcasts to a generic `CableReadyBroadccastJob` which is autoloaded from `app/jobs`.

Using `apply!` on the `operations_payload` this was a no-brainer, the only gotcha being that class stream identifiers of course cannot be serialized as such, so I had to do `identifier.name` on the sending and `identifier.safe_constantize` on the receiving side in case a `model` is present.