### PR TITLE
console_table operation

### DIFF
--- a/javascript/operations.js
+++ b/javascript/operations.js
@@ -391,6 +391,13 @@ export default {
     })
   },
 
+  consoleTable: (operation, callee) => {
+    operate(operation, () => {
+      const { data, columns } = operation
+      console.table(data, columns || [])
+    })
+  },
+
   notification: (operation, callee) => {
     before(document, callee, operation)
     operate(operation, () => {

--- a/lib/cable_ready/config.rb
+++ b/lib/cable_ready/config.rb
@@ -42,6 +42,7 @@ module CableReady
         append
         clear_storage
         console_log
+        console_table
         dispatch_event
         go
         graft


### PR DESCRIPTION
Implements https://developer.mozilla.org/en-US/docs/Web/API/Console/table as an operation.

Options:
- data
- columns

Anything passed to data is sent into the table. It expects an array or object, but fails very gracefully.
Columns defaults to `[]` and must be an array of strings if passed.

```rb
cable_ready.console_table(data: [{marco: 5, nate: 2}, {marco:4, nate: 6}], columns: ['marco']).broadcast
```

<img width="432" alt="chrome_1JoQAFw3hE" src="https://user-images.githubusercontent.com/38150464/118344853-92a65800-b4fe-11eb-93d4-b461adf2410c.png">

Thanks to @MatheusRich for the idea!
