### PR TITLE
Remove warning message for already registered custom element

### DIFF
--- a/javascript/stream_from_element.js
+++ b/javascript/stream_from_element.js
@@ -35,16 +35,6 @@ class StreamFromElement extends HTMLElement {
   }
 }
 
-const customElement = window.customElements.get('stream-from')
-
-if (customElement) {
-  if (customElement !== StreamFromElement) {
-    console.warn(
-      'CableReady tried to register the HTML custom element `stream-from`, but `stream-from` is already registered and used by something else. Make sure that nothing else defines the custom element `stream-from`.'
-    )
-  } else {
-    // CableReady has already registered the `stream-from` custom element and it's the right one
-  }
-} else {
+if (!window.customElements.get('stream-from')) {
   window.customElements.define('stream-from', StreamFromElement)
 }


### PR DESCRIPTION
# Type of PR

"Bug fix"

## Description

In #124 I introduced a warning message that would warn a developer if the custom element `stream-from` was already registered. It turns out that we can't check it that easily with our setup - especially if you are using CableReady via a different package in your app. 

Long story short: This PR removes that check since it always showed the warning message, even if everything was fine.

## Why should this be added

To avoid confusion about the already registered custom element.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update

