### PR TITLE
Re-export consumer

### DIFF
--- a/javascript/cable_ready.js
+++ b/javascript/cable_ready.js
@@ -84,3 +84,5 @@ const initialize = (initializeOptions = {}) => {
 }
 
 export { perform, performAsync, initialize }
+
+export const consumer = actionCable.getConsumer()

--- a/javascript/elements/stream_from_element.js
+++ b/javascript/elements/stream_from_element.js
@@ -4,7 +4,7 @@ import SubscribingElement from './subscribing_element'
 export default class StreamFromElement extends SubscribingElement {
   async connectedCallback () {
     if (this.preview) return
-    const consumer = await this.consumer()
+    const consumer = await CableReady.consumer
     if (consumer) {
       this.createSubscription(
         consumer,

--- a/javascript/elements/subscribing_element.js
+++ b/javascript/elements/subscribing_element.js
@@ -1,4 +1,4 @@
-import actionCable from '../action_cable'
+import CableReady from '..'
 
 export default class SubscribingElement extends HTMLElement {
   disconnectedCallback () {
@@ -15,10 +15,6 @@ export default class SubscribingElement extends HTMLElement {
         received: receivedCallback
       }
     )
-  }
-
-  consumer () {
-    return actionCable.getConsumer()
   }
 
   get preview () {

--- a/javascript/elements/updates_for_element.js
+++ b/javascript/elements/updates_for_element.js
@@ -1,5 +1,6 @@
 import morphdom from 'morphdom'
 
+import CableReady from '..'
 import SubscribingElement from './subscribing_element'
 import { shouldMorph } from '../morph_callbacks'
 import activeElement from '../active_element'
@@ -29,7 +30,7 @@ export default class UpdatesForElement extends SubscribingElement {
     if (this.preview) return
     this.update = debounce(this.update.bind(this), this.debounce)
 
-    const consumer = await this.consumer()
+    const consumer = await CableReady.consumer
     if (consumer) {
       this.createSubscription(consumer, 'CableReady::Stream', this.update)
     } else {

--- a/javascript/index.js
+++ b/javascript/index.js
@@ -2,7 +2,7 @@ import * as MorphCallbacks from './morph_callbacks'
 import { shouldMorphCallbacks, didMorphCallbacks } from './morph_callbacks'
 import * as Utils from './utils'
 import OperationStore, { addOperation, addOperations } from './operation_store'
-import { perform, performAsync, initialize } from './cable_ready'
+import { perform, performAsync, initialize, consumer } from './cable_ready'
 import StreamFromElement from './elements/stream_from_element'
 import UpdatesForElement from './elements/updates_for_element'
 import SubscribingElement from './elements/subscribing_element'
@@ -21,6 +21,7 @@ export default {
   shouldMorphCallbacks,
   didMorphCallbacks,
   initialize,
+  consumer,
   addOperation,
   addOperations,
   get DOMOperations () {


### PR DESCRIPTION
As a further simplification, re-export the consumer so it can easily be obtained by calling

`await CableReady.consumer`

This can even be re-used among sub-libraries like StimulusReflex, Futurism, and potentially more