### PR TITLE
Add custom header to fetch

### DIFF
--- a/javascript/elements/updates_for_element.js
+++ b/javascript/elements/updates_for_element.js
@@ -53,7 +53,11 @@ export default class UpdatesForElement extends SubscribingElement {
       blocks[i].setAttribute('updating', 'updating')
 
       if (!html.hasOwnProperty(url(blocks[i]))) {
-        const response = await fetch(url(blocks[i]))
+        const response = await fetch(url(blocks[i]), {
+          headers: {
+            'X-Cable-Ready': 'update'
+          }
+        })
           .then(handleErrors)
           .catch(e => console.error(`Could not fetch ${url(blocks[i])}`))
         if (response === undefined) return


### PR DESCRIPTION
Adds a custom header `X-Cable-Ready: update` to the fetch call, to discern it from "normal" calls in the backend