### PR TITLE
fix: graciouslyFetch returns undefined on network error, crashes updates_for callers

### DIFF
--- a/javascript/elements/updates_for_element.js
+++ b/javascript/elements/updates_for_element.js
@@ -120,7 +120,7 @@ export default class UpdatesForElement extends SubscribingElement {
           const response = await graciouslyFetch(url, {
             'X-Cable-Ready': 'update'
           })
-          this.html[url] = await response.text()
+          if (response) this.html[url] = await response.text()
         }
       })
     )
@@ -254,7 +254,7 @@ class Block {
           )
 
           const frameTemplate = document.createElement('template')
-          frameTemplate.innerHTML = await frameResponse.text()
+          if (frameResponse) frameTemplate.innerHTML = await frameResponse.text()
 
           // recurse here to get all nested eager loaded frames
           await this.resolveTurboFrames(frameTemplate.content)

--- a/javascript/elements/updates_for_element.js
+++ b/javascript/elements/updates_for_element.js
@@ -254,7 +254,8 @@ class Block {
           )
 
           const frameTemplate = document.createElement('template')
-          if (frameResponse) frameTemplate.innerHTML = await frameResponse.text()
+          if (frameResponse)
+            frameTemplate.innerHTML = await frameResponse.text()
 
           // recurse here to get all nested eager loaded frames
           await this.resolveTurboFrames(frameTemplate.content)

--- a/javascript/utils.js
+++ b/javascript/utils.js
@@ -173,9 +173,15 @@ function safeObject (obj) {
 
 function safeStringOrArray (elem) {
   if (elem !== undefined && !Array.isArray(elem) && typeof elem !== 'string')
-    console.warn(`Operation expects an Array or a String, but got ${elem} (${typeof elem})`)
+    console.warn(
+      `Operation expects an Array or a String, but got ${elem} (${typeof elem})`
+    )
 
-  return elem == null ? '' : Array.isArray(elem) ? Array.from(elem) : String(elem)
+  return elem == null
+    ? ''
+    : Array.isArray(elem)
+    ? Array.from(elem)
+    : String(elem)
 }
 
 function fragmentToString (fragment) {

--- a/javascript/utils.js
+++ b/javascript/utils.js
@@ -202,6 +202,7 @@ async function graciouslyFetch (url, additionalHeaders) {
     return response
   } catch (e) {
     console.error(`Could not fetch ${url}`)
+    return new Response('')
   }
 }
 


### PR DESCRIPTION
## Summary

- `graciouslyFetch()` in `utils.js` catches fetch errors but implicitly returns `undefined`, causing `TypeError: Cannot read properties of undefined (reading 'text')` at two call sites in `updates_for_element.js`
- Fix: return `new Response('')` in the catch block so callers always get a valid Response
- Add defensive `if (response)` guards at both call sites for defense in depth

Fixes #310

## Changes

**`javascript/utils.js`** - Return `new Response('')` in catch block instead of returning nothing

**`javascript/elements/updates_for_element.js`** - Guard both `.text()` call sites:
- Line 123: `if (response) this.html[url] = await response.text()`
- Line 257: `if (frameResponse) frameTemplate.innerHTML = await frameResponse.text()`